### PR TITLE
Fix GraphQL type mismatches between schema and Prisma

### DIFF
--- a/indexer/src/api/scalars.ts
+++ b/indexer/src/api/scalars.ts
@@ -39,6 +39,10 @@ export const BigIntScalar = new GraphQLScalarType({
     if (value instanceof Decimal) {
       return value.toFixed(0);
     }
+    // Handle Prisma Decimal (different class than decimal.js Decimal)
+    if (value !== null && typeof value === 'object' && 'toFixed' in value && typeof (value as { toFixed: unknown }).toFixed === 'function') {
+      return (value as { toFixed: (dp: number) => string }).toFixed(0);
+    }
     if (typeof value === 'string' || typeof value === 'number') {
       return value.toString();
     }

--- a/indexer/src/api/schema.graphql
+++ b/indexer/src/api/schema.graphql
@@ -16,7 +16,7 @@ type Market {
   debtDenom: String!
   oracle: String!
   createdAt: DateTime!
-  createdAtBlock: Int!
+  createdAtBlock: BigInt!
 
   # Parameters
   loanToValue: Decimal!
@@ -42,7 +42,7 @@ type Market {
   totalCollateral: BigInt!
   utilization: Decimal!
   availableLiquidity: BigInt!
-  lastUpdate: Int!
+  lastUpdate: BigInt!
 
   # Relations
   positions(limit: Int, offset: Int): [UserPosition!]!
@@ -99,7 +99,7 @@ enum TransactionAction {
 type Transaction {
   id: ID!
   txHash: String!
-  blockHeight: Int!
+  blockHeight: BigInt!
   timestamp: DateTime!
   market: Market!
   userAddress: String!
@@ -132,7 +132,7 @@ type MarketSnapshot {
   id: ID!
   market: Market!
   timestamp: DateTime!
-  blockHeight: Int!
+  blockHeight: BigInt!
 
   borrowIndex: Decimal!
   liquidityIndex: Decimal!
@@ -153,7 +153,7 @@ type InterestAccrualEvent {
   market: Market!
   txHash: String!
   timestamp: DateTime!
-  blockHeight: Int!
+  blockHeight: BigInt!
 
   borrowIndex: Decimal!
   liquidityIndex: Decimal!

--- a/indexer/src/events/parser.ts
+++ b/indexer/src/events/parser.ts
@@ -1,17 +1,15 @@
-import { Event as TendermintEvent } from '@cosmjs/tendermint-rpc';
+import { Event as TendermintEvent } from '@cosmjs/tendermint-rpc/build/tendermint37/responses';
 import { Event as StargateEvent } from '@cosmjs/stargate';
-import { MarketCreatedEvent, MarketEvent, BlockchainEvent } from './types';
+import { MarketEvent, BlockchainEvent } from './types';
 import { logger } from '../utils/logger';
 
 /**
- * Parse event attributes from Tendermint RPC events (Uint8Array keys/values)
+ * Parse event attributes from Tendermint RPC events (tendermint37 has string keys/values)
  */
 export function parseEventAttributes(event: TendermintEvent): Record<string, string> {
   const attributes: Record<string, string> = {};
   for (const attr of event.attributes) {
-    const key = Buffer.from(attr.key).toString('utf-8');
-    const value = Buffer.from(attr.value).toString('utf-8');
-    attributes[key] = value;
+    attributes[attr.key] = attr.value;
   }
   return attributes;
 }

--- a/indexer/src/indexer/block-processor.ts
+++ b/indexer/src/indexer/block-processor.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { Event as TendermintEvent } from '@cosmjs/tendermint-rpc';
+import { Event as TendermintEvent } from '@cosmjs/tendermint-rpc/build/tendermint37/responses';
 import { getTendermintClient } from '../utils/blockchain';
 import { logger } from '../utils/logger';
 import { config } from '../config';


### PR DESCRIPTION
## Summary

- Change `createdAtBlock`, `lastUpdate`, and `blockHeight` from `Int` to `BigInt` in GraphQL schema to match Prisma BigInt types
- Fix BigInt scalar to handle Prisma Decimal objects (used for large numbers like `totalCollateral`)
- Update tendermint event imports to use tendermint37 types (fixes build errors)
- Remove unused `MarketCreatedEvent` import

## Context

These issues were discovered by the new GraphQL schema validation tests (coming in a separate PR). The tests query every field on every type and validate the returned data types match expectations.

### Issues Fixed

1. **Type mismatch: `Int` vs `BigInt`** - Fields like `createdAtBlock` were defined as `Int` in the GraphQL schema but stored as `BigInt` in Prisma, causing serialization errors.

2. **BigInt scalar didn't handle Prisma Decimal** - Fields like `totalCollateral` use Prisma's `Decimal` type for large numbers, but the BigInt scalar didn't know how to serialize them.

3. **Tendermint type version mismatch** - The indexer imported tendermint34 event types but the actual chain responses use tendermint37 format.

## Test plan

- [x] Rebuild indexer Docker container
- [x] Run GraphQL schema validation tests - all pass
- [x] Verify `totalCollateral`, `createdAtBlock`, `lastUpdate` fields return correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)