### PR TITLE
Fix frontend build errors

### DIFF
--- a/frontend/lib/graphql/client.ts
+++ b/frontend/lib/graphql/client.ts
@@ -5,9 +5,9 @@ import {
   InMemoryCache,
   HttpLink,
   split,
-} from '@apollo/client/index.js';
-import { GraphQLWsLink } from '@apollo/client/link/subscriptions/index.js';
-import { getMainDefinition } from '@apollo/client/utilities/index.js';
+} from '@apollo/client';
+import { GraphQLWsLink } from '@apollo/client/link/subscriptions';
+import { getMainDefinition } from '@apollo/client/utilities';
 import { createClient } from 'graphql-ws';
 
 const httpLink = new HttpLink({

--- a/frontend/lib/utils/format.ts
+++ b/frontend/lib/utils/format.ts
@@ -13,7 +13,7 @@ export function formatDisplayAmount(amount: string | number, maxDecimals: number
   if (isNaN(value)) return '0.00';
 
   return new Intl.NumberFormat('en-US', {
-    minimumFractionDigits: 2,
+    minimumFractionDigits: Math.min(2, maxDecimals),
     maximumFractionDigits: maxDecimals,
   }).format(value);
 }


### PR DESCRIPTION
## Summary
- Fix `RangeError: maximumFractionDigits value is out of range` when `formatDisplayAmount` is called with `maxDecimals: 0`
- Fix Apollo Client import paths that were incompatible with Next.js 16 Turbopack

## Test plan
- [x] Run `npm run dev` in frontend directory
- [x] Verify markets page loads without NumberFormat errors
- [x] Verify Apollo Client connects to GraphQL endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)