### PR TITLE
Display actual createdAt and curator on market details page

### DIFF
--- a/frontend/app/markets/[id]/page.tsx
+++ b/frontend/app/markets/[id]/page.tsx
@@ -205,13 +205,9 @@ export default function MarketDetailPage() {
               Curator
               <Info className="h-3.5 w-3.5" />
             </div>
-            <div className="flex items-center gap-2 mt-2">
-              <div className="flex -space-x-1">
-                <div className="h-6 w-6 rounded-full bg-blue-500 flex items-center justify-center text-white text-xs ring-2 ring-background">
-                  S
-                </div>
-              </div>
-            </div>
+            <p className="text-lg font-medium font-mono" title={market.curator}>
+              {market.curator.slice(0, 8)}...{market.curator.slice(-4)}
+            </p>
           </div>
         </div>
 
@@ -339,7 +335,19 @@ export default function MarketDetailPage() {
                       </div>
                       <div className="flex items-center justify-between">
                         <span className="text-muted-foreground">Created on</span>
-                        <span className="font-medium">2024-09-04</span>
+                        <span className="font-medium">
+                          {new Date(market.createdAt).toLocaleDateString('en-US', {
+                            year: 'numeric',
+                            month: 'short',
+                            day: 'numeric',
+                          })}
+                        </span>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <span className="text-muted-foreground">Created by</span>
+                        <span className="font-medium font-mono text-sm" title={market.curator}>
+                          {market.curator.slice(0, 10)}...{market.curator.slice(-6)}
+                        </span>
                       </div>
                       <div className="flex items-center justify-between">
                         <span className="text-muted-foreground">Liquidation LTV</span>

--- a/frontend/hooks/useMarkets.ts
+++ b/frontend/hooks/useMarkets.ts
@@ -45,6 +45,7 @@ function transformMarketDetail(market: MarketFieldsFragment): MarketDetail {
     utilization: parseFloat(market.utilization) * 100,
     availableLiquidity: market.availableLiquidity,
     loanToValue: parseFloat(market.loanToValue) * 100,
+    createdAt: market.createdAt,
     info: {
       market_id: market.id,
       address: market.marketAddress,

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -20,6 +20,7 @@ export interface Market {
 }
 
 export interface MarketDetail extends Market {
+  createdAt: string;
   info: {
     market_id: string;
     address: string;


### PR DESCRIPTION
## Summary
- Replace hardcoded "2024-09-04" date with actual `createdAt` timestamp from the indexer
- Show truncated curator address in the header stats section (was showing hardcoded "S")
- Add "Created by" row in Market Attributes section showing the curator address

## Test plan
- [ ] Navigate to a market details page and verify the "Created on" date is no longer 2024-09-04
- [ ] Verify the Curator field in the stats row shows the actual truncated address
- [ ] Verify the "Created by" row appears in Market Attributes with the curator address
- [ ] Hover over curator addresses to verify full address shows in tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)