### PR TITLE
Add comprehensive testing framework for indexer

### DIFF
--- a/indexer/package.json
+++ b/indexer/package.json
@@ -12,7 +12,13 @@
     "db:migrate": "prisma migrate dev",
     "db:studio": "prisma studio",
     "lint": "eslint src --ext .ts",
-    "format": "prettier --write \"src/**/*.ts\""
+    "format": "prettier --write \"src/**/*.ts\"",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "test:unit": "vitest run tests/unit",
+    "test:integration": "vitest run tests/integration",
+    "test:scenarios": "vitest run tests/scenarios"
   },
   "keywords": [
     "cosmwasm",
@@ -49,11 +55,13 @@
     "@types/ws": "^8.5.10",
     "@typescript-eslint/eslint-plugin": "^6.17.0",
     "@typescript-eslint/parser": "^6.17.0",
+    "@vitest/coverage-v8": "^2.1.0",
     "eslint": "^8.56.0",
     "prettier": "^3.1.1",
     "prisma": "^5.22.0",
     "tsx": "^4.7.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^2.1.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/indexer/tests/helpers/assertions.ts
+++ b/indexer/tests/helpers/assertions.ts
@@ -1,0 +1,240 @@
+import { expect } from 'vitest';
+import { Decimal } from 'decimal.js';
+import { prisma } from '../../src/db/client';
+
+// Helper to compare decimal values properly (handles scientific notation)
+export function decimalEquals(actual: Decimal | { toString: () => string } | null | undefined, expected: string): boolean {
+  if (actual === null || actual === undefined) return false;
+  const actualDec = new Decimal(actual.toString());
+  const expectedDec = new Decimal(expected);
+  return actualDec.equals(expectedDec);
+}
+
+// Assertion helper for decimal comparison - use this instead of .toBe() for decimals
+export function expectDecimalEquals(actual: Decimal | { toString: () => string } | null | undefined, expected: string): void {
+  const actualStr = actual?.toString() ?? 'null';
+  const equals = decimalEquals(actual, expected);
+  if (!equals) {
+    const actualDec = actual ? new Decimal(actual.toString()) : null;
+    expect.fail(`Expected decimal ${actualStr} (${actualDec?.toFixed()}) to equal ${expected}`);
+  }
+}
+
+// Assert market state
+export async function assertMarketState(
+  marketId: string,
+  expected: {
+    totalSupplyScaled?: string;
+    totalDebtScaled?: string;
+    totalCollateral?: string;
+    borrowIndex?: string;
+    liquidityIndex?: string;
+    borrowRate?: string;
+    liquidityRate?: string;
+  }
+) {
+  const market = await prisma.market.findUnique({ where: { id: marketId } });
+  expect(market).not.toBeNull();
+
+  if (expected.totalSupplyScaled !== undefined) {
+    expect(decimalEquals(market!.totalSupplyScaled, expected.totalSupplyScaled)).toBe(true);
+  }
+  if (expected.totalDebtScaled !== undefined) {
+    expect(decimalEquals(market!.totalDebtScaled, expected.totalDebtScaled)).toBe(true);
+  }
+  if (expected.totalCollateral !== undefined) {
+    expect(decimalEquals(market!.totalCollateral, expected.totalCollateral)).toBe(true);
+  }
+  if (expected.borrowIndex !== undefined) {
+    expect(decimalEquals(market!.borrowIndex, expected.borrowIndex)).toBe(true);
+  }
+  if (expected.liquidityIndex !== undefined) {
+    expect(decimalEquals(market!.liquidityIndex, expected.liquidityIndex)).toBe(true);
+  }
+  if (expected.borrowRate !== undefined) {
+    expect(decimalEquals(market!.borrowRate, expected.borrowRate)).toBe(true);
+  }
+  if (expected.liquidityRate !== undefined) {
+    expect(decimalEquals(market!.liquidityRate, expected.liquidityRate)).toBe(true);
+  }
+}
+
+// Assert user position state
+export async function assertPositionState(
+  marketId: string,
+  userAddress: string,
+  expected: {
+    supplyScaled?: string;
+    debtScaled?: string;
+    collateral?: string;
+    exists?: boolean;
+  }
+) {
+  const positionId = `${marketId}:${userAddress}`;
+  const position = await prisma.userPosition.findUnique({ where: { id: positionId } });
+
+  if (expected.exists === false) {
+    expect(position).toBeNull();
+    return;
+  }
+
+  expect(position).not.toBeNull();
+
+  if (expected.supplyScaled !== undefined) {
+    expect(decimalEquals(position!.supplyScaled, expected.supplyScaled)).toBe(true);
+  }
+  if (expected.debtScaled !== undefined) {
+    expect(decimalEquals(position!.debtScaled, expected.debtScaled)).toBe(true);
+  }
+  if (expected.collateral !== undefined) {
+    expect(decimalEquals(position!.collateral, expected.collateral)).toBe(true);
+  }
+}
+
+// Assert transaction was created
+export async function assertTransactionCreated(
+  txHash: string,
+  logIndex: number,
+  expected: {
+    action: string;
+    marketId: string;
+    userAddress: string;
+    amount?: string;
+    scaledAmount?: string;
+    recipient?: string;
+    liquidator?: string;
+    borrower?: string;
+    debtRepaid?: string;
+    collateralSeized?: string;
+    protocolFee?: string;
+  }
+) {
+  const txId = `${txHash}:${logIndex}`;
+  const transaction = await prisma.transaction.findUnique({ where: { id: txId } });
+
+  expect(transaction).not.toBeNull();
+  expect(transaction!.action).toBe(expected.action);
+  expect(transaction!.marketId).toBe(expected.marketId);
+  expect(transaction!.userAddress).toBe(expected.userAddress);
+
+  if (expected.amount !== undefined) {
+    expect(transaction!.amount?.toString()).toBe(expected.amount);
+  }
+  if (expected.scaledAmount !== undefined) {
+    expect(transaction!.scaledAmount?.toString()).toBe(expected.scaledAmount);
+  }
+  if (expected.recipient !== undefined) {
+    expect(transaction!.recipient).toBe(expected.recipient);
+  }
+  if (expected.liquidator !== undefined) {
+    expect(transaction!.liquidator).toBe(expected.liquidator);
+  }
+  if (expected.borrower !== undefined) {
+    expect(transaction!.borrower).toBe(expected.borrower);
+  }
+  if (expected.debtRepaid !== undefined) {
+    expect(transaction!.debtRepaid?.toString()).toBe(expected.debtRepaid);
+  }
+  if (expected.collateralSeized !== undefined) {
+    expect(transaction!.collateralSeized?.toString()).toBe(expected.collateralSeized);
+  }
+  if (expected.protocolFee !== undefined) {
+    expect(transaction!.protocolFee?.toString()).toBe(expected.protocolFee);
+  }
+}
+
+// Assert interest accrual event was created
+export async function assertInterestAccrualCreated(
+  txHash: string,
+  logIndex: number,
+  expected: {
+    marketId: string;
+    borrowIndex: string;
+    liquidityIndex: string;
+    borrowRate: string;
+    liquidityRate: string;
+  }
+) {
+  const eventId = `${txHash}:${logIndex}`;
+  const event = await prisma.interestAccrualEvent.findUnique({ where: { id: eventId } });
+
+  expect(event).not.toBeNull();
+  expect(event!.marketId).toBe(expected.marketId);
+  expect(event!.borrowIndex.toString()).toBe(expected.borrowIndex);
+  expect(event!.liquidityIndex.toString()).toBe(expected.liquidityIndex);
+  expect(event!.borrowRate.toString()).toBe(expected.borrowRate);
+  expect(event!.liquidityRate.toString()).toBe(expected.liquidityRate);
+}
+
+// Assert market snapshot was created
+export async function assertMarketSnapshotCreated(
+  marketId: string,
+  timestamp: number,
+  expected: {
+    loanToValue?: string;
+    liquidationThreshold?: string;
+    enabled?: boolean;
+  }
+) {
+  const snapshotId = `${marketId}:${timestamp}`;
+  const snapshot = await prisma.marketSnapshot.findUnique({ where: { id: snapshotId } });
+
+  expect(snapshot).not.toBeNull();
+
+  if (expected.loanToValue !== undefined) {
+    expect(snapshot!.loanToValue.toString()).toBe(expected.loanToValue);
+  }
+  if (expected.liquidationThreshold !== undefined) {
+    expect(snapshot!.liquidationThreshold.toString()).toBe(expected.liquidationThreshold);
+  }
+  if (expected.enabled !== undefined) {
+    expect(snapshot!.enabled).toBe(expected.enabled);
+  }
+}
+
+// Assert no transaction exists
+export async function assertNoTransaction(txHash: string, logIndex: number) {
+  const txId = `${txHash}:${logIndex}`;
+  const transaction = await prisma.transaction.findUnique({ where: { id: txId } });
+  expect(transaction).toBeNull();
+}
+
+// Assert total count of records
+export async function assertRecordCount(
+  table: 'market' | 'userPosition' | 'transaction' | 'marketSnapshot' | 'interestAccrualEvent',
+  expectedCount: number
+) {
+  let count: number;
+  switch (table) {
+    case 'market':
+      count = await prisma.market.count();
+      break;
+    case 'userPosition':
+      count = await prisma.userPosition.count();
+      break;
+    case 'transaction':
+      count = await prisma.transaction.count();
+      break;
+    case 'marketSnapshot':
+      count = await prisma.marketSnapshot.count();
+      break;
+    case 'interestAccrualEvent':
+      count = await prisma.interestAccrualEvent.count();
+      break;
+  }
+  expect(count).toBe(expectedCount);
+}
+
+// Compare two decimal values with tolerance
+export function assertDecimalClose(
+  actual: Decimal | string,
+  expected: string,
+  tolerance: string = '0.000000000000000001'
+) {
+  const actualDec = new Decimal(actual.toString());
+  const expectedDec = new Decimal(expected);
+  const toleranceDec = new Decimal(tolerance);
+
+  const diff = actualDec.minus(expectedDec).abs();
+  expect(diff.lte(toleranceDec)).toBe(true);
+}

--- a/indexer/tests/helpers/events.ts
+++ b/indexer/tests/helpers/events.ts
@@ -1,0 +1,265 @@
+import { ADDRESSES, DECIMALS, generateTxHash } from './fixtures';
+import type {
+  SupplyEvent,
+  WithdrawEvent,
+  SupplyCollateralEvent,
+  WithdrawCollateralEvent,
+  BorrowEvent,
+  RepayEvent,
+  LiquidateEvent,
+  AccrueInterestEvent,
+  UpdateParamsEvent,
+} from '../../src/events/types';
+import type { PartialMarketCreatedEvent } from '../../src/events/parser';
+
+// Base event metadata
+export interface EventMetadata {
+  txHash?: string;
+  blockHeight?: number;
+  timestamp?: number;
+  logIndex?: number;
+}
+
+function getMetadata(overrides: EventMetadata = {}) {
+  return {
+    txHash: overrides.txHash ?? generateTxHash(),
+    blockHeight: overrides.blockHeight ?? 12345,
+    timestamp: overrides.timestamp ?? Math.floor(Date.now() / 1000),
+    logIndex: overrides.logIndex ?? 0,
+  };
+}
+
+// Create a market created event
+export function createMarketCreatedEvent(
+  overrides: Partial<PartialMarketCreatedEvent> & EventMetadata = {}
+): PartialMarketCreatedEvent {
+  const meta = getMetadata(overrides);
+  return {
+    action: 'market_instantiated',
+    marketId: overrides.marketId ?? '1',
+    marketAddress: overrides.marketAddress ?? ADDRESSES.market1,
+    ...meta,
+  };
+}
+
+// Create a supply event
+export function createSupplyEvent(
+  overrides: Partial<Omit<SupplyEvent, 'action'>> & EventMetadata = {}
+): SupplyEvent {
+  const meta = getMetadata(overrides);
+  return {
+    action: 'supply',
+    supplier: overrides.supplier ?? ADDRESSES.userA,
+    recipient: overrides.recipient ?? overrides.supplier ?? ADDRESSES.userA,
+    amount: overrides.amount ?? DECIMALS.oneToken,
+    scaledAmount: overrides.scaledAmount ?? DECIMALS.oneToken,
+    totalSupply: overrides.totalSupply ?? DECIMALS.oneToken,
+    totalDebt: overrides.totalDebt ?? DECIMALS.zero,
+    utilization: overrides.utilization ?? DECIMALS.zeroUtilization,
+    marketAddress: overrides.marketAddress ?? ADDRESSES.market1,
+    ...meta,
+  };
+}
+
+// Create a withdraw event
+export function createWithdrawEvent(
+  overrides: Partial<Omit<WithdrawEvent, 'action'>> & EventMetadata = {}
+): WithdrawEvent {
+  const meta = getMetadata(overrides);
+  return {
+    action: 'withdraw',
+    withdrawer: overrides.withdrawer ?? ADDRESSES.userA,
+    recipient: overrides.recipient ?? overrides.withdrawer ?? ADDRESSES.userA,
+    amount: overrides.amount ?? DECIMALS.oneToken,
+    scaledDecrease: overrides.scaledDecrease ?? DECIMALS.oneToken,
+    totalSupply: overrides.totalSupply ?? DECIMALS.zero,
+    totalDebt: overrides.totalDebt ?? DECIMALS.zero,
+    utilization: overrides.utilization ?? DECIMALS.zeroUtilization,
+    marketAddress: overrides.marketAddress ?? ADDRESSES.market1,
+    ...meta,
+  };
+}
+
+// Create a supply collateral event
+export function createSupplyCollateralEvent(
+  overrides: Partial<Omit<SupplyCollateralEvent, 'action'>> & EventMetadata = {}
+): SupplyCollateralEvent {
+  const meta = getMetadata(overrides);
+  return {
+    action: 'supply_collateral',
+    supplier: overrides.supplier ?? ADDRESSES.userA,
+    recipient: overrides.recipient ?? overrides.supplier ?? ADDRESSES.userA,
+    amount: overrides.amount ?? DECIMALS.oneToken,
+    marketAddress: overrides.marketAddress ?? ADDRESSES.market1,
+    ...meta,
+  };
+}
+
+// Create a withdraw collateral event
+export function createWithdrawCollateralEvent(
+  overrides: Partial<Omit<WithdrawCollateralEvent, 'action'>> & EventMetadata = {}
+): WithdrawCollateralEvent {
+  const meta = getMetadata(overrides);
+  return {
+    action: 'withdraw_collateral',
+    withdrawer: overrides.withdrawer ?? ADDRESSES.userA,
+    recipient: overrides.recipient ?? overrides.withdrawer ?? ADDRESSES.userA,
+    amount: overrides.amount ?? DECIMALS.oneToken,
+    marketAddress: overrides.marketAddress ?? ADDRESSES.market1,
+    ...meta,
+  };
+}
+
+// Create a borrow event
+export function createBorrowEvent(
+  overrides: Partial<Omit<BorrowEvent, 'action'>> & EventMetadata = {}
+): BorrowEvent {
+  const meta = getMetadata(overrides);
+  return {
+    action: 'borrow',
+    borrower: overrides.borrower ?? ADDRESSES.userA,
+    recipient: overrides.recipient ?? overrides.borrower ?? ADDRESSES.userA,
+    amount: overrides.amount ?? DECIMALS.oneToken,
+    scaledAmount: overrides.scaledAmount ?? DECIMALS.oneToken,
+    totalSupply: overrides.totalSupply ?? DECIMALS.thousand,
+    totalDebt: overrides.totalDebt ?? DECIMALS.oneToken,
+    utilization: overrides.utilization ?? DECIMALS.tenPercentUtilization,
+    marketAddress: overrides.marketAddress ?? ADDRESSES.market1,
+    ...meta,
+  };
+}
+
+// Create a repay event
+export function createRepayEvent(
+  overrides: Partial<Omit<RepayEvent, 'action'>> & EventMetadata = {}
+): RepayEvent {
+  const meta = getMetadata(overrides);
+  return {
+    action: 'repay',
+    repayer: overrides.repayer ?? ADDRESSES.userA,
+    borrower: overrides.borrower ?? overrides.repayer ?? ADDRESSES.userA,
+    amount: overrides.amount ?? DECIMALS.oneToken,
+    scaledDecrease: overrides.scaledDecrease ?? DECIMALS.oneToken,
+    totalSupply: overrides.totalSupply ?? DECIMALS.thousand,
+    totalDebt: overrides.totalDebt ?? DECIMALS.zero,
+    utilization: overrides.utilization ?? DECIMALS.zeroUtilization,
+    marketAddress: overrides.marketAddress ?? ADDRESSES.market1,
+    ...meta,
+  };
+}
+
+// Create a liquidate event
+export function createLiquidateEvent(
+  overrides: Partial<Omit<LiquidateEvent, 'action'>> & EventMetadata = {}
+): LiquidateEvent {
+  const meta = getMetadata(overrides);
+  return {
+    action: 'liquidate',
+    liquidator: overrides.liquidator ?? ADDRESSES.liquidator,
+    borrower: overrides.borrower ?? ADDRESSES.userA,
+    debtRepaid: overrides.debtRepaid ?? DECIMALS.oneToken,
+    collateralSeized: overrides.collateralSeized ?? DECIMALS.oneToken,
+    protocolFee: overrides.protocolFee ?? DECIMALS.dust,
+    scaledDebtDecrease: overrides.scaledDebtDecrease ?? DECIMALS.oneToken,
+    totalSupply: overrides.totalSupply ?? DECIMALS.thousand,
+    totalDebt: overrides.totalDebt ?? DECIMALS.zero,
+    totalCollateral: overrides.totalCollateral ?? DECIMALS.zero,
+    utilization: overrides.utilization ?? DECIMALS.zeroUtilization,
+    marketAddress: overrides.marketAddress ?? ADDRESSES.market1,
+    ...meta,
+  };
+}
+
+// Create an accrue interest event
+export function createAccrueInterestEvent(
+  overrides: Partial<Omit<AccrueInterestEvent, 'action'>> & EventMetadata = {}
+): AccrueInterestEvent {
+  const meta = getMetadata(overrides);
+  return {
+    action: 'accrue_interest',
+    borrowIndex: overrides.borrowIndex ?? '1.05',
+    liquidityIndex: overrides.liquidityIndex ?? '1.03',
+    borrowRate: overrides.borrowRate ?? '0.05',
+    liquidityRate: overrides.liquidityRate ?? '0.03',
+    lastUpdate: overrides.lastUpdate ?? String(meta.timestamp),
+    marketAddress: overrides.marketAddress ?? ADDRESSES.market1,
+    ...meta,
+  };
+}
+
+// Create an update params event
+export function createUpdateParamsEvent(
+  overrides: Partial<Omit<UpdateParamsEvent, 'action'>> & EventMetadata = {}
+): UpdateParamsEvent {
+  const meta = getMetadata(overrides);
+  return {
+    action: 'update_params',
+    marketAddress: overrides.marketAddress ?? ADDRESSES.market1,
+    finalLtv: overrides.finalLtv ?? '0.8',
+    finalLiquidationThreshold: overrides.finalLiquidationThreshold ?? '0.85',
+    finalLiquidationBonus: overrides.finalLiquidationBonus ?? '0.05',
+    finalLiquidationProtocolFee: overrides.finalLiquidationProtocolFee ?? '0.1',
+    finalCloseFactor: overrides.finalCloseFactor ?? '0.5',
+    finalProtocolFee: overrides.finalProtocolFee ?? '0.1',
+    finalCuratorFee: overrides.finalCuratorFee ?? '0.05',
+    finalSupplyCap: overrides.finalSupplyCap,
+    finalBorrowCap: overrides.finalBorrowCap,
+    finalEnabled: overrides.finalEnabled ?? 'true',
+    finalIsMutable: overrides.finalIsMutable ?? 'true',
+    ...meta,
+  };
+}
+
+// Convert event to raw attributes (as would come from blockchain)
+export function eventToRawAttributes(
+  event: SupplyEvent | WithdrawEvent | BorrowEvent | RepayEvent | LiquidateEvent
+): Record<string, string> {
+  const attrs: Record<string, string> = {
+    action: event.action,
+  };
+
+  if ('supplier' in event) {
+    attrs.supplier = event.supplier;
+    attrs.recipient = event.recipient;
+  }
+  if ('withdrawer' in event) {
+    attrs.withdrawer = event.withdrawer;
+    attrs.recipient = event.recipient;
+  }
+  if ('borrower' in event && 'repayer' in event) {
+    attrs.repayer = event.repayer;
+    attrs.borrower = event.borrower;
+  } else if ('borrower' in event && !('liquidator' in event)) {
+    attrs.borrower = event.borrower;
+    attrs.recipient = event.recipient;
+  }
+  if ('liquidator' in event) {
+    attrs.liquidator = event.liquidator;
+    attrs.borrower = event.borrower;
+    attrs.debt_repaid = event.debtRepaid;
+    attrs.collateral_seized = event.collateralSeized;
+    attrs.protocol_fee = event.protocolFee;
+    attrs.scaled_debt_decrease = event.scaledDebtDecrease;
+    attrs.total_collateral = event.totalCollateral;
+  }
+  if ('amount' in event) {
+    attrs.amount = event.amount;
+  }
+  if ('scaledAmount' in event) {
+    attrs.scaled_amount = event.scaledAmount;
+  }
+  if ('scaledDecrease' in event) {
+    attrs.scaled_decrease = event.scaledDecrease;
+  }
+  if ('totalSupply' in event) {
+    attrs.total_supply = event.totalSupply;
+  }
+  if ('totalDebt' in event) {
+    attrs.total_debt = event.totalDebt;
+  }
+  if ('utilization' in event) {
+    attrs.utilization = event.utilization;
+  }
+
+  return attrs;
+}

--- a/indexer/tests/helpers/fixtures.ts
+++ b/indexer/tests/helpers/fixtures.ts
@@ -1,0 +1,149 @@
+import { Decimal } from 'decimal.js';
+import { prisma } from '../../src/db/client';
+
+// Test addresses
+export const ADDRESSES = {
+  factory: 'cosmos1factoryqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq',
+  market1: 'cosmos1market1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq',
+  market2: 'cosmos1market2qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq',
+  userA: 'cosmos1useraqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq',
+  userB: 'cosmos1userbqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq',
+  userC: 'cosmos1usercqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq',
+  curator: 'cosmos1curatorqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq',
+  oracle: 'cosmos1oracleqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq',
+  liquidator: 'cosmos1liquidatorqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq',
+};
+
+// Decimal test values
+export const DECIMALS = {
+  maxUint128: '340282366920938463463374607431768211455',
+  oneToken: '1000000000000000000', // 1e18
+  thousand: '1000000000000000000000', // 1000e18
+  million: '1000000000000000000000000', // 1M e18
+  dust: '1',
+  zero: '0',
+  // Utilization ratios (stored as decimal values 0-1, not raw 18-decimal integers)
+  // These are used for utilization field which is Decimal(20,18) in the DB
+  zeroUtilization: '0',
+  tenPercentUtilization: '0.1',
+  fiftyPercentUtilization: '0.5',
+  eightyPercentUtilization: '0.8',
+  hundredPercentUtilization: '1',
+  // Aliases for utilization (used directly in tests)
+  tenPercent: '0.1',
+  fiftyPercent: '0.5',
+  eightyPercent: '0.8',
+};
+
+// Default market parameters
+export const DEFAULT_MARKET_PARAMS = {
+  loanToValue: new Decimal('0.8'),
+  liquidationThreshold: new Decimal('0.85'),
+  liquidationBonus: new Decimal('0.05'),
+  liquidationProtocolFee: new Decimal('0.1'),
+  closeFactor: new Decimal('0.5'),
+  protocolFee: new Decimal('0.1'),
+  curatorFee: new Decimal('0.05'),
+  interestRateModel: {
+    optimal_utilization: '0.8',
+    base_rate: '0.02',
+    slope1: '0.04',
+    slope2: '0.75',
+  },
+};
+
+// Create a market in the database
+export async function createTestMarket(overrides: Partial<{
+  id: string;
+  marketAddress: string;
+  curator: string;
+  collateralDenom: string;
+  debtDenom: string;
+  oracle: string;
+  totalSupplyScaled: Decimal;
+  totalDebtScaled: Decimal;
+  totalCollateral: Decimal;
+  borrowIndex: Decimal;
+  liquidityIndex: Decimal;
+}> = {}) {
+  const id = overrides.id ?? '1';
+  const marketAddress = overrides.marketAddress ?? ADDRESSES.market1;
+
+  return prisma.market.create({
+    data: {
+      id,
+      marketAddress,
+      curator: overrides.curator ?? ADDRESSES.curator,
+      collateralDenom: overrides.collateralDenom ?? 'ueth',
+      debtDenom: overrides.debtDenom ?? 'uusdc',
+      oracle: overrides.oracle ?? ADDRESSES.oracle,
+      createdAt: new Date(),
+      createdAtBlock: BigInt(1),
+      ...DEFAULT_MARKET_PARAMS,
+      supplyCap: null,
+      borrowCap: null,
+      enabled: true,
+      isMutable: true,
+      borrowIndex: overrides.borrowIndex ?? new Decimal('1'),
+      liquidityIndex: overrides.liquidityIndex ?? new Decimal('1'),
+      borrowRate: new Decimal('0.05'),
+      liquidityRate: new Decimal('0.03'),
+      totalSupplyScaled: overrides.totalSupplyScaled ?? new Decimal('0'),
+      totalDebtScaled: overrides.totalDebtScaled ?? new Decimal('0'),
+      totalCollateral: overrides.totalCollateral ?? new Decimal('0'),
+      lastUpdate: BigInt(Math.floor(Date.now() / 1000)),
+      utilization: new Decimal('0'),
+      availableLiquidity: new Decimal('0'),
+    },
+  });
+}
+
+// Create a user position in the database
+export async function createTestPosition(
+  marketId: string,
+  userAddress: string,
+  overrides: Partial<{
+    supplyScaled: Decimal;
+    debtScaled: Decimal;
+    collateral: Decimal;
+  }> = {}
+) {
+  return prisma.userPosition.create({
+    data: {
+      id: `${marketId}:${userAddress}`,
+      marketId,
+      userAddress,
+      supplyScaled: overrides.supplyScaled ?? new Decimal('0'),
+      debtScaled: overrides.debtScaled ?? new Decimal('0'),
+      collateral: overrides.collateral ?? new Decimal('0'),
+      firstInteraction: new Date(),
+      lastInteraction: new Date(),
+    },
+  });
+}
+
+// Create indexer state
+export async function createIndexerState(
+  lastProcessedBlock: number,
+  lastProcessedHash?: string
+) {
+  return prisma.indexerState.create({
+    data: {
+      id: 'singleton',
+      lastProcessedBlock: BigInt(lastProcessedBlock),
+      lastProcessedHash: lastProcessedHash ?? 'abc123',
+    },
+  });
+}
+
+// Generate a unique tx hash
+let txCounter = 0;
+export function generateTxHash(): string {
+  txCounter++;
+  return `TX${txCounter.toString().padStart(62, '0')}`.toUpperCase();
+}
+
+// Reset tx counter between tests
+export function resetTxCounter() {
+  txCounter = 0;
+}

--- a/indexer/tests/helpers/index.ts
+++ b/indexer/tests/helpers/index.ts
@@ -1,0 +1,4 @@
+export * from './fixtures';
+export * from './mocks';
+export * from './assertions';
+export * from './events';

--- a/indexer/tests/helpers/mocks.ts
+++ b/indexer/tests/helpers/mocks.ts
@@ -1,0 +1,172 @@
+import { vi } from 'vitest';
+import type { Event as TendermintEvent } from '@cosmjs/tendermint-rpc/build/tendermint37/responses';
+
+// Mock block structure
+export interface MockTransaction {
+  bytes: string; // base64 encoded tx bytes
+  code: number; // 0 for success, non-zero for failure
+  events: TendermintEvent[];
+}
+
+export interface MockBlock {
+  height: number;
+  hash: string;
+  timestamp: number;
+  txs: MockTransaction[];
+}
+
+// Create a mock Tendermint client
+export function createMockTendermintClient(blocks: MockBlock[]) {
+  const blockMap = new Map(blocks.map((b) => [b.height, b]));
+
+  return {
+    block: vi.fn((height: number) => {
+      const block = blockMap.get(height);
+      if (!block) {
+        throw new Error(`Block ${height} not found`);
+      }
+      // Hash should be provided as hex string, decode to Buffer
+      // The caller will convert back via Buffer.from(hash).toString('hex')
+      return {
+        blockId: { hash: Buffer.from(block.hash, 'hex') },
+        block: {
+          header: { time: new Date(block.timestamp * 1000) },
+          txs: block.txs.map((tx) => Buffer.from(tx.bytes, 'base64')),
+        },
+      };
+    }),
+    blockResults: vi.fn((height: number) => {
+      const block = blockMap.get(height);
+      if (!block) {
+        throw new Error(`Block ${height} not found`);
+      }
+      return {
+        results: block.txs.map((tx) => ({
+          code: tx.code,
+          events: tx.events,
+        })),
+      };
+    }),
+    status: vi.fn(() => ({
+      syncInfo: {
+        latestBlockHeight: Math.max(...blocks.map((b) => b.height)),
+      },
+    })),
+  };
+}
+
+// Create a wasm event with string key/value attributes
+export function createWasmEvent(
+  contractAddress: string,
+  attributes: Record<string, string>
+): TendermintEvent {
+  const allAttributes: Array<{ key: string; value: string }> = [
+    { key: '_contract_address', value: contractAddress },
+  ];
+
+  for (const [key, value] of Object.entries(attributes)) {
+    allAttributes.push({ key, value });
+  }
+
+  return {
+    type: 'wasm',
+    attributes: allAttributes,
+  } as TendermintEvent;
+}
+
+// Create a mock CosmWasm client for querying market config
+export interface MockMarketConfig {
+  curator: string;
+  collateralDenom: string;
+  debtDenom: string;
+  oracle: string;
+  params: {
+    loan_to_value: string;
+    liquidation_threshold: string;
+    liquidation_bonus: string;
+    liquidation_protocol_fee: string;
+    close_factor: string;
+    interest_rate_model: object;
+    protocol_fee: string;
+    curator_fee: string;
+    supply_cap: string | null;
+    borrow_cap: string | null;
+    enabled: boolean;
+    is_mutable: boolean;
+  };
+}
+
+export function createMockCosmWasmClient(marketConfigs: Record<string, MockMarketConfig>) {
+  return {
+    queryContractSmart: vi.fn((address: string, query: object) => {
+      const config = marketConfigs[address];
+      if (!config) {
+        throw new Error(`Unknown market: ${address}`);
+      }
+
+      if ('config' in query) {
+        return {
+          curator: config.curator,
+          collateral_denom: config.collateralDenom,
+          debt_denom: config.debtDenom,
+          oracle: config.oracle,
+        };
+      }
+
+      if ('params' in query) {
+        return config.params;
+      }
+
+      throw new Error(`Unknown query: ${JSON.stringify(query)}`);
+    }),
+  };
+}
+
+// Create mock queryMarketInfo response
+export function createMockMarketInfo(overrides: Partial<MockMarketConfig> = {}): {
+  config: {
+    curator: string;
+    collateral_denom: string;
+    debt_denom: string;
+    oracle: string;
+  };
+  params: MockMarketConfig['params'];
+} {
+  const defaults: MockMarketConfig = {
+    curator: 'cosmos1curator...',
+    collateralDenom: 'ueth',
+    debtDenom: 'uusdc',
+    oracle: 'cosmos1oracle...',
+    params: {
+      loan_to_value: '0.8',
+      liquidation_threshold: '0.85',
+      liquidation_bonus: '0.05',
+      liquidation_protocol_fee: '0.1',
+      close_factor: '0.5',
+      interest_rate_model: {
+        optimal_utilization: '0.8',
+        base_rate: '0.02',
+        slope1: '0.04',
+        slope2: '0.75',
+      },
+      protocol_fee: '0.1',
+      curator_fee: '0.05',
+      supply_cap: null,
+      borrow_cap: null,
+      enabled: true,
+      is_mutable: true,
+    },
+  };
+
+  const merged = { ...defaults, ...overrides };
+
+  return {
+    config: {
+      curator: merged.curator,
+      collateral_denom: merged.collateralDenom,
+      debt_denom: merged.debtDenom,
+      oracle: merged.oracle,
+    },
+    params: merged.params,
+  };
+}

--- a/indexer/tests/integration/block-processor.test.ts
+++ b/indexer/tests/integration/block-processor.test.ts
@@ -1,0 +1,403 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Decimal } from 'decimal.js';
+import {
+  processBlock,
+  getLastProcessedBlock,
+  updateLastProcessedBlock,
+  loadMarketAddresses,
+} from '../../src/indexer/block-processor';
+import { getTendermintClient, queryMarketInfo } from '../../src/utils/blockchain';
+import { prisma } from '../../src/db/client';
+import { config } from '../../src/config';
+import {
+  ADDRESSES,
+  DECIMALS,
+  createTestMarket,
+  createIndexerState,
+  createMockTendermintClient,
+  createWasmEvent,
+  createMockMarketInfo,
+  assertMarketState,
+  assertPositionState,
+  assertRecordCount,
+} from '../helpers';
+import type { MockBlock } from '../helpers/mocks';
+
+const mockedGetTendermintClient = vi.mocked(getTendermintClient);
+const mockedQueryMarketInfo = vi.mocked(queryMarketInfo);
+
+describe('Block Processor Integration', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Reset config for tests
+    vi.spyOn(config.contracts, 'factoryAddress', 'get').mockReturnValue(ADDRESSES.factory);
+  });
+
+  describe('getLastProcessedBlock', () => {
+    it('returns configured start block when no state exists', async () => {
+      vi.spyOn(config.indexer, 'startBlockHeight', 'get').mockReturnValue(100);
+
+      const result = await getLastProcessedBlock();
+
+      expect(result).toBe(100);
+    });
+
+    it('returns stored block height when state exists', async () => {
+      await createIndexerState(500);
+
+      const result = await getLastProcessedBlock();
+
+      expect(result).toBe(500);
+    });
+  });
+
+  describe('updateLastProcessedBlock', () => {
+    it('creates IndexerState if not exists', async () => {
+      await updateLastProcessedBlock(100, 'abc123');
+
+      const state = await prisma.indexerState.findUnique({
+        where: { id: 'singleton' },
+      });
+
+      expect(state).not.toBeNull();
+      expect(Number(state!.lastProcessedBlock)).toBe(100);
+      expect(state!.lastProcessedHash).toBe('abc123');
+    });
+
+    it('updates existing IndexerState', async () => {
+      await createIndexerState(50, 'oldhash');
+
+      await updateLastProcessedBlock(100, 'newhash');
+
+      const state = await prisma.indexerState.findUnique({
+        where: { id: 'singleton' },
+      });
+
+      expect(Number(state!.lastProcessedBlock)).toBe(100);
+      expect(state!.lastProcessedHash).toBe('newhash');
+    });
+  });
+
+  describe('loadMarketAddresses', () => {
+    it('loads market addresses from database', async () => {
+      await createTestMarket({ id: '1', marketAddress: ADDRESSES.market1 });
+      await createTestMarket({ id: '2', marketAddress: ADDRESSES.market2 });
+
+      await loadMarketAddresses();
+
+      // We can't directly test the internal Set, but we can verify by processing events
+      // The function should have loaded 2 addresses
+      const markets = await prisma.market.count();
+      expect(markets).toBe(2);
+    });
+  });
+
+  describe('processBlock', () => {
+    it('processes block with supply event and updates database', async () => {
+      // Setup: create market and load addresses
+      await createTestMarket({ id: '1', marketAddress: ADDRESSES.market1 });
+      await loadMarketAddresses();
+
+      // Create mock block with supply event
+      const supplyEvent = createWasmEvent(ADDRESSES.market1, {
+        action: 'supply',
+        supplier: ADDRESSES.userA,
+        recipient: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+        scaled_amount: DECIMALS.oneToken,
+        total_supply: DECIMALS.oneToken,
+        total_debt: DECIMALS.zero,
+        utilization: DECIMALS.zero,
+      });
+
+      const mockBlock: MockBlock = {
+        height: 100,
+        hash: 'abc123def456abc123def456abc123def456abc123def456abc123def456abc1',
+        timestamp: 1700000000,
+        txs: [
+          {
+            bytes: Buffer.from('tx1').toString('base64'),
+            code: 0,
+            events: [supplyEvent],
+          },
+        ],
+      };
+
+      mockedGetTendermintClient.mockResolvedValue(
+        createMockTendermintClient([mockBlock]) as any
+      );
+
+      await processBlock(100);
+
+      // Verify market was updated
+      await assertMarketState('1', {
+        totalSupplyScaled: DECIMALS.oneToken,
+      });
+
+      // Verify position was created
+      await assertPositionState('1', ADDRESSES.userA, {
+        supplyScaled: DECIMALS.oneToken,
+      });
+
+      // Verify transaction was created
+      await assertRecordCount('transaction', 1);
+
+      // Verify checkpoint was updated
+      const state = await prisma.indexerState.findUnique({
+        where: { id: 'singleton' },
+      });
+      expect(Number(state!.lastProcessedBlock)).toBe(100);
+    });
+
+    it('processes block with multiple transactions', async () => {
+      await createTestMarket({
+        id: '1',
+        marketAddress: ADDRESSES.market1,
+        totalSupplyScaled: new Decimal(DECIMALS.thousand),
+      });
+      await loadMarketAddresses();
+
+      const supplyEvent1 = createWasmEvent(ADDRESSES.market1, {
+        action: 'supply',
+        supplier: ADDRESSES.userA,
+        recipient: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+        scaled_amount: DECIMALS.oneToken,
+        total_supply: '1001000000000000000000',
+        total_debt: DECIMALS.zero,
+        utilization: DECIMALS.zero,
+      });
+
+      const supplyEvent2 = createWasmEvent(ADDRESSES.market1, {
+        action: 'supply',
+        supplier: ADDRESSES.userB,
+        recipient: ADDRESSES.userB,
+        amount: DECIMALS.oneToken,
+        scaled_amount: DECIMALS.oneToken,
+        total_supply: '1002000000000000000000',
+        total_debt: DECIMALS.zero,
+        utilization: DECIMALS.zero,
+      });
+
+      const mockBlock: MockBlock = {
+        height: 100,
+        hash: 'abc123',
+        timestamp: 1700000000,
+        txs: [
+          { bytes: Buffer.from('tx1').toString('base64'), code: 0, events: [supplyEvent1] },
+          { bytes: Buffer.from('tx2').toString('base64'), code: 0, events: [supplyEvent2] },
+        ],
+      };
+
+      mockedGetTendermintClient.mockResolvedValue(
+        createMockTendermintClient([mockBlock]) as any
+      );
+
+      await processBlock(100);
+
+      // Both positions should be created
+      await assertPositionState('1', ADDRESSES.userA, {
+        supplyScaled: DECIMALS.oneToken,
+      });
+      await assertPositionState('1', ADDRESSES.userB, {
+        supplyScaled: DECIMALS.oneToken,
+      });
+
+      // Two transactions
+      await assertRecordCount('transaction', 2);
+    });
+
+    it('processes block with multiple events per transaction', async () => {
+      await createTestMarket({ id: '1', marketAddress: ADDRESSES.market1 });
+      await loadMarketAddresses();
+
+      const supplyEvent = createWasmEvent(ADDRESSES.market1, {
+        action: 'supply',
+        supplier: ADDRESSES.userA,
+        recipient: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+        scaled_amount: DECIMALS.oneToken,
+        total_supply: DECIMALS.oneToken,
+        total_debt: DECIMALS.zero,
+        utilization: DECIMALS.zero,
+      });
+
+      const accrueEvent = createWasmEvent(ADDRESSES.market1, {
+        action: 'accrue_interest',
+        borrow_index: '1.01',
+        liquidity_index: '1.005',
+        borrow_rate: '0.05',
+        liquidity_rate: '0.03',
+        last_update: '1700000000',
+      });
+
+      const mockBlock: MockBlock = {
+        height: 100,
+        hash: 'abc123',
+        timestamp: 1700000000,
+        txs: [
+          {
+            bytes: Buffer.from('tx1').toString('base64'),
+            code: 0,
+            events: [supplyEvent, accrueEvent],
+          },
+        ],
+      };
+
+      mockedGetTendermintClient.mockResolvedValue(
+        createMockTendermintClient([mockBlock]) as any
+      );
+
+      await processBlock(100);
+
+      // Both events should be processed
+      await assertRecordCount('transaction', 1); // Supply creates transaction
+      await assertRecordCount('interestAccrualEvent', 1); // AccrueInterest creates event
+
+      // Market should have updated indices
+      await assertMarketState('1', {
+        borrowIndex: '1.01',
+        liquidityIndex: '1.005',
+      });
+    });
+
+    it('skips failed transactions (code !== 0)', async () => {
+      await createTestMarket({ id: '1', marketAddress: ADDRESSES.market1 });
+      await loadMarketAddresses();
+
+      const supplyEvent = createWasmEvent(ADDRESSES.market1, {
+        action: 'supply',
+        supplier: ADDRESSES.userA,
+        recipient: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+        scaled_amount: DECIMALS.oneToken,
+        total_supply: DECIMALS.oneToken,
+        total_debt: DECIMALS.zero,
+        utilization: DECIMALS.zero,
+      });
+
+      const mockBlock: MockBlock = {
+        height: 100,
+        hash: 'abc123',
+        timestamp: 1700000000,
+        txs: [
+          {
+            bytes: Buffer.from('tx1').toString('base64'),
+            code: 1, // Failed transaction
+            events: [supplyEvent],
+          },
+        ],
+      };
+
+      mockedGetTendermintClient.mockResolvedValue(
+        createMockTendermintClient([mockBlock]) as any
+      );
+
+      await processBlock(100);
+
+      // No changes should be made
+      await assertMarketState('1', {
+        totalSupplyScaled: '0',
+      });
+      await assertRecordCount('transaction', 0);
+      await assertPositionState('1', ADDRESSES.userA, { exists: false });
+    });
+
+    it('handles empty block (no transactions)', async () => {
+      const mockBlock: MockBlock = {
+        height: 100,
+        hash: 'abc123',
+        timestamp: 1700000000,
+        txs: [],
+      };
+
+      mockedGetTendermintClient.mockResolvedValue(
+        createMockTendermintClient([mockBlock]) as any
+      );
+
+      await processBlock(100);
+
+      // Checkpoint should still be updated
+      const state = await prisma.indexerState.findUnique({
+        where: { id: 'singleton' },
+      });
+      expect(Number(state!.lastProcessedBlock)).toBe(100);
+    });
+
+    it('ignores events from unknown contracts', async () => {
+      await createTestMarket({ id: '1', marketAddress: ADDRESSES.market1 });
+      await loadMarketAddresses();
+
+      // Event from unknown contract
+      const unknownEvent = createWasmEvent('cosmos1unknown...', {
+        action: 'supply',
+        supplier: ADDRESSES.userA,
+        recipient: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+        scaled_amount: DECIMALS.oneToken,
+        total_supply: DECIMALS.oneToken,
+        total_debt: DECIMALS.zero,
+        utilization: DECIMALS.zero,
+      });
+
+      const mockBlock: MockBlock = {
+        height: 100,
+        hash: 'abc123',
+        timestamp: 1700000000,
+        txs: [
+          {
+            bytes: Buffer.from('tx1').toString('base64'),
+            code: 0,
+            events: [unknownEvent],
+          },
+        ],
+      };
+
+      mockedGetTendermintClient.mockResolvedValue(
+        createMockTendermintClient([mockBlock]) as any
+      );
+
+      await processBlock(100);
+
+      // No changes to market
+      await assertMarketState('1', {
+        totalSupplyScaled: '0',
+      });
+      await assertRecordCount('transaction', 0);
+    });
+
+    it('processes market_instantiated event from factory', async () => {
+      mockedQueryMarketInfo.mockResolvedValue(createMockMarketInfo());
+
+      const marketCreatedEvent = createWasmEvent(ADDRESSES.factory, {
+        action: 'market_instantiated',
+        market_id: '1',
+        market_address: ADDRESSES.market1,
+      });
+
+      const mockBlock: MockBlock = {
+        height: 100,
+        hash: 'abc123',
+        timestamp: 1700000000,
+        txs: [
+          {
+            bytes: Buffer.from('tx1').toString('base64'),
+            code: 0,
+            events: [marketCreatedEvent],
+          },
+        ],
+      };
+
+      mockedGetTendermintClient.mockResolvedValue(
+        createMockTendermintClient([mockBlock]) as any
+      );
+
+      await processBlock(100);
+
+      // Market should be created
+      await assertRecordCount('market', 1);
+      const market = await prisma.market.findUnique({ where: { id: '1' } });
+      expect(market!.marketAddress).toBe(ADDRESSES.market1);
+    });
+  });
+});

--- a/indexer/tests/integration/reorg-handling.test.ts
+++ b/indexer/tests/integration/reorg-handling.test.ts
@@ -1,0 +1,387 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Decimal } from 'decimal.js';
+import {
+  detectReorg,
+  handleReorg,
+} from '../../src/indexer/block-processor';
+import { getTendermintClient } from '../../src/utils/blockchain';
+import { prisma } from '../../src/db/client';
+import { config } from '../../src/config';
+import {
+  ADDRESSES,
+  DECIMALS,
+  createTestMarket,
+  createTestPosition,
+  createIndexerState,
+  createMockTendermintClient,
+  assertRecordCount,
+} from '../helpers';
+import type { MockBlock } from '../helpers/mocks';
+
+const mockedGetTendermintClient = vi.mocked(getTendermintClient);
+
+describe('Reorg Handling', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.spyOn(config.indexer, 'startBlockHeight', 'get').mockReturnValue(1);
+  });
+
+  describe('detectReorg', () => {
+    it('returns false when no state exists', async () => {
+      const result = await detectReorg(100);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when current height is less than or equal to last processed', async () => {
+      await createIndexerState(100, 'abc123');
+
+      const result = await detectReorg(100);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when hash matches', async () => {
+      const hash = 'abc123def456abc123def456abc123def456abc123def456abc123def456abc1';
+      await createIndexerState(100, hash);
+
+      const mockBlock: MockBlock = {
+        height: 100,
+        hash,
+        timestamp: 1700000000,
+        txs: [],
+      };
+
+      mockedGetTendermintClient.mockResolvedValue(
+        createMockTendermintClient([mockBlock]) as any
+      );
+
+      const result = await detectReorg(101);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns true when hash differs (reorg detected)', async () => {
+      await createIndexerState(100, 'oldhash');
+
+      const mockBlock: MockBlock = {
+        height: 100,
+        hash: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef', // Different hash
+        timestamp: 1700000000,
+        txs: [],
+      };
+
+      mockedGetTendermintClient.mockResolvedValue(
+        createMockTendermintClient([mockBlock]) as any
+      );
+
+      const result = await detectReorg(101);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false on RPC error (fails safe)', async () => {
+      await createIndexerState(100, 'abc123');
+
+      mockedGetTendermintClient.mockRejectedValue(new Error('Network error'));
+
+      const result = await detectReorg(101);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('handleReorg', () => {
+    it('deletes transactions from affected blocks', async () => {
+      await createIndexerState(100, 'oldhash');
+      await createTestMarket({ id: '1', marketAddress: ADDRESSES.market1 });
+
+      // Create transactions at different block heights
+      await prisma.transaction.createMany({
+        data: [
+          {
+            id: 'tx1:0',
+            txHash: 'tx1',
+            blockHeight: BigInt(95),
+            timestamp: new Date(),
+            marketId: '1',
+            userAddress: ADDRESSES.userA,
+            action: 'SUPPLY',
+            amount: new Decimal(DECIMALS.oneToken),
+          },
+          {
+            id: 'tx2:0',
+            txHash: 'tx2',
+            blockHeight: BigInt(100),
+            timestamp: new Date(),
+            marketId: '1',
+            userAddress: ADDRESSES.userA,
+            action: 'SUPPLY',
+            amount: new Decimal(DECIMALS.oneToken),
+          },
+          {
+            id: 'tx3:0',
+            txHash: 'tx3',
+            blockHeight: BigInt(105),
+            timestamp: new Date(),
+            marketId: '1',
+            userAddress: ADDRESSES.userA,
+            action: 'SUPPLY',
+            amount: new Decimal(DECIMALS.oneToken),
+          },
+        ],
+      });
+
+      // Create safe block for reorg handler
+      const mockBlock: MockBlock = {
+        height: 90, // safeHeight = 100 - 10 = 90
+        hash: 'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234',
+        timestamp: 1700000000,
+        txs: [],
+      };
+
+      mockedGetTendermintClient.mockResolvedValue(
+        createMockTendermintClient([mockBlock]) as any
+      );
+
+      await handleReorg(100);
+
+      // Transactions from blocks >= 90 should be deleted
+      await assertRecordCount('transaction', 0);
+    });
+
+    it('deletes InterestAccrualEvents from affected blocks', async () => {
+      await createIndexerState(100, 'oldhash');
+      await createTestMarket({ id: '1', marketAddress: ADDRESSES.market1 });
+
+      await prisma.interestAccrualEvent.createMany({
+        data: [
+          {
+            id: 'event1:0',
+            marketId: '1',
+            txHash: 'tx1',
+            timestamp: new Date(),
+            blockHeight: BigInt(85),
+            borrowIndex: new Decimal('1.01'),
+            liquidityIndex: new Decimal('1.005'),
+            borrowRate: new Decimal('0.05'),
+            liquidityRate: new Decimal('0.03'),
+          },
+          {
+            id: 'event2:0',
+            marketId: '1',
+            txHash: 'tx2',
+            timestamp: new Date(),
+            blockHeight: BigInt(95),
+            borrowIndex: new Decimal('1.02'),
+            liquidityIndex: new Decimal('1.01'),
+            borrowRate: new Decimal('0.05'),
+            liquidityRate: new Decimal('0.03'),
+          },
+        ],
+      });
+
+      const mockBlock: MockBlock = {
+        height: 90,
+        hash: 'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234',
+        timestamp: 1700000000,
+        txs: [],
+      };
+
+      mockedGetTendermintClient.mockResolvedValue(
+        createMockTendermintClient([mockBlock]) as any
+      );
+
+      await handleReorg(100);
+
+      // Event at block 85 should be preserved, event at block 95 deleted
+      await assertRecordCount('interestAccrualEvent', 1);
+    });
+
+    it('deletes MarketSnapshots from affected blocks', async () => {
+      await createIndexerState(100, 'oldhash');
+      await createTestMarket({ id: '1', marketAddress: ADDRESSES.market1 });
+
+      await prisma.marketSnapshot.createMany({
+        data: [
+          {
+            id: '1:1700000000',
+            marketId: '1',
+            timestamp: new Date(1700000000 * 1000),
+            blockHeight: BigInt(85),
+            borrowIndex: new Decimal('1'),
+            liquidityIndex: new Decimal('1'),
+            borrowRate: new Decimal('0.05'),
+            liquidityRate: new Decimal('0.03'),
+            totalSupply: new Decimal('0'),
+            totalDebt: new Decimal('0'),
+            totalCollateral: new Decimal('0'),
+            utilization: new Decimal('0'),
+            loanToValue: new Decimal('0.8'),
+            liquidationThreshold: new Decimal('0.85'),
+            enabled: true,
+          },
+          {
+            id: '1:1700001000',
+            marketId: '1',
+            timestamp: new Date(1700001000 * 1000),
+            blockHeight: BigInt(95),
+            borrowIndex: new Decimal('1.01'),
+            liquidityIndex: new Decimal('1.005'),
+            borrowRate: new Decimal('0.05'),
+            liquidityRate: new Decimal('0.03'),
+            totalSupply: new Decimal(DECIMALS.thousand),
+            totalDebt: new Decimal(DECIMALS.oneToken),
+            totalCollateral: new Decimal('0'),
+            utilization: new Decimal('0.1'),
+            loanToValue: new Decimal('0.8'),
+            liquidationThreshold: new Decimal('0.85'),
+            enabled: true,
+          },
+        ],
+      });
+
+      const mockBlock: MockBlock = {
+        height: 90,
+        hash: 'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234',
+        timestamp: 1700000000,
+        txs: [],
+      };
+
+      mockedGetTendermintClient.mockResolvedValue(
+        createMockTendermintClient([mockBlock]) as any
+      );
+
+      await handleReorg(100);
+
+      // Snapshot at block 85 should be preserved (85 < 90), snapshot at 95 deleted
+      await assertRecordCount('marketSnapshot', 1);
+    });
+
+    it('preserves Markets (not deleted during reorg)', async () => {
+      await createIndexerState(100, 'oldhash');
+      await createTestMarket({ id: '1', marketAddress: ADDRESSES.market1 });
+      await createTestMarket({ id: '2', marketAddress: ADDRESSES.market2 });
+
+      const mockBlock: MockBlock = {
+        height: 90,
+        hash: 'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234',
+        timestamp: 1700000000,
+        txs: [],
+      };
+
+      mockedGetTendermintClient.mockResolvedValue(
+        createMockTendermintClient([mockBlock]) as any
+      );
+
+      await handleReorg(100);
+
+      // Markets should still exist
+      await assertRecordCount('market', 2);
+    });
+
+    it('preserves UserPositions (not deleted during reorg)', async () => {
+      await createIndexerState(100, 'oldhash');
+      await createTestMarket({ id: '1', marketAddress: ADDRESSES.market1 });
+      await createTestPosition('1', ADDRESSES.userA, {
+        supplyScaled: new Decimal(DECIMALS.thousand),
+      });
+      await createTestPosition('1', ADDRESSES.userB, {
+        supplyScaled: new Decimal(DECIMALS.thousand),
+      });
+
+      const mockBlock: MockBlock = {
+        height: 90,
+        hash: 'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234',
+        timestamp: 1700000000,
+        txs: [],
+      };
+
+      mockedGetTendermintClient.mockResolvedValue(
+        createMockTendermintClient([mockBlock]) as any
+      );
+
+      await handleReorg(100);
+
+      // Positions should still exist
+      await assertRecordCount('userPosition', 2);
+    });
+
+    it('resets IndexerState to safe height', async () => {
+      await createIndexerState(100, 'oldhash');
+      await createTestMarket({ id: '1', marketAddress: ADDRESSES.market1 });
+
+      const safeHash = '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+      const mockBlock: MockBlock = {
+        height: 90,
+        hash: safeHash,
+        timestamp: 1700000000,
+        txs: [],
+      };
+
+      mockedGetTendermintClient.mockResolvedValue(
+        createMockTendermintClient([mockBlock]) as any
+      );
+
+      await handleReorg(100);
+
+      const state = await prisma.indexerState.findUnique({
+        where: { id: 'singleton' },
+      });
+
+      expect(Number(state!.lastProcessedBlock)).toBe(90);
+      expect(state!.lastProcessedHash).toBe(safeHash);
+    });
+
+    it('uses startBlockHeight as minimum safe height', async () => {
+      vi.spyOn(config.indexer, 'startBlockHeight', 'get').mockReturnValue(95);
+      await createIndexerState(100, 'oldhash');
+      await createTestMarket({ id: '1', marketAddress: ADDRESSES.market1 });
+
+      const mockBlock: MockBlock = {
+        height: 95, // startBlockHeight
+        hash: 'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234',
+        timestamp: 1700000000,
+        txs: [],
+      };
+
+      mockedGetTendermintClient.mockResolvedValue(
+        createMockTendermintClient([mockBlock]) as any
+      );
+
+      await handleReorg(100);
+
+      const state = await prisma.indexerState.findUnique({
+        where: { id: 'singleton' },
+      });
+
+      // Should not go below startBlockHeight
+      expect(Number(state!.lastProcessedBlock)).toBe(95);
+    });
+
+    it('handles reorg at very low block height', async () => {
+      vi.spyOn(config.indexer, 'startBlockHeight', 'get').mockReturnValue(1);
+      await createIndexerState(5, 'oldhash');
+      await createTestMarket({ id: '1', marketAddress: ADDRESSES.market1 });
+
+      const mockBlock: MockBlock = {
+        height: 1, // Can't go below startBlockHeight
+        hash: 'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234',
+        timestamp: 1700000000,
+        txs: [],
+      };
+
+      mockedGetTendermintClient.mockResolvedValue(
+        createMockTendermintClient([mockBlock]) as any
+      );
+
+      await handleReorg(5);
+
+      const state = await prisma.indexerState.findUnique({
+        where: { id: 'singleton' },
+      });
+
+      expect(Number(state!.lastProcessedBlock)).toBe(1);
+    });
+  });
+});

--- a/indexer/tests/scenarios/lending-flow.test.ts
+++ b/indexer/tests/scenarios/lending-flow.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Decimal } from 'decimal.js';
+import {
+  handleSupply,
+  handleBorrow,
+  handleRepay,
+  handleWithdraw,
+  handleAccrueInterest,
+} from '../../src/events/handlers';
+import { prisma } from '../../src/db/client';
+import {
+  ADDRESSES,
+  DECIMALS,
+  createTestMarket,
+  createSupplyEvent,
+  createBorrowEvent,
+  createRepayEvent,
+  createWithdrawEvent,
+  createAccrueInterestEvent,
+  assertMarketState,
+  assertPositionState,
+  assertRecordCount,
+  expectDecimalEquals,
+} from '../helpers';
+
+describe('Lending Flow Scenarios', () => {
+  const marketId = '1';
+
+  describe('Complete lending cycle: Supply -> Borrow -> Repay -> Withdraw', () => {
+    beforeEach(async () => {
+      await createTestMarket({ id: marketId });
+    });
+
+    it('processes full lending flow with interest accrual', async () => {
+      const supplier = ADDRESSES.userA;
+      const borrower = ADDRESSES.userB;
+
+      // Step 1: Supplier deposits 1000 tokens
+      const supplyAmount = DECIMALS.thousand;
+      await handleSupply(
+        createSupplyEvent({
+          supplier,
+          recipient: supplier,
+          amount: supplyAmount,
+          scaledAmount: supplyAmount,
+          totalSupply: supplyAmount,
+          totalDebt: DECIMALS.zero,
+          utilization: DECIMALS.zero,
+          logIndex: 0,
+        }),
+        marketId
+      );
+
+      await assertMarketState(marketId, {
+        totalSupplyScaled: supplyAmount,
+        totalDebtScaled: '0',
+      });
+
+      await assertPositionState(marketId, supplier, {
+        supplyScaled: supplyAmount,
+        debtScaled: '0',
+      });
+
+      // Step 2: Borrower borrows 500 tokens
+      const borrowAmount = '500000000000000000000';
+      await handleBorrow(
+        createBorrowEvent({
+          borrower,
+          recipient: borrower,
+          amount: borrowAmount,
+          scaledAmount: borrowAmount,
+          totalSupply: supplyAmount,
+          totalDebt: borrowAmount,
+          utilization: '0.5', // 50%
+          logIndex: 1,
+        }),
+        marketId
+      );
+
+      await assertMarketState(marketId, {
+        totalSupplyScaled: supplyAmount,
+        totalDebtScaled: borrowAmount,
+      });
+
+      await assertPositionState(marketId, borrower, {
+        debtScaled: borrowAmount,
+      });
+
+      // Step 3: Interest accrues (indices increase)
+      await handleAccrueInterest(
+        createAccrueInterestEvent({
+          borrowIndex: '1.05',
+          liquidityIndex: '1.025',
+          borrowRate: '0.1',
+          liquidityRate: '0.05',
+          logIndex: 2,
+        }),
+        marketId
+      );
+
+      await assertMarketState(marketId, {
+        borrowIndex: '1.05',
+        liquidityIndex: '1.025',
+      });
+
+      // Step 4: Borrower repays full debt
+      // Actual repay would be 500 * 1.05 = 525, but scaled decrease is still 500
+      await handleRepay(
+        createRepayEvent({
+          repayer: borrower,
+          borrower,
+          amount: '525000000000000000000', // With interest
+          scaledDecrease: borrowAmount,
+          totalSupply: supplyAmount,
+          totalDebt: DECIMALS.zero,
+          utilization: DECIMALS.zero,
+          logIndex: 3,
+        }),
+        marketId
+      );
+
+      await assertMarketState(marketId, {
+        totalDebtScaled: '0',
+      });
+
+      await assertPositionState(marketId, borrower, {
+        debtScaled: '0',
+      });
+
+      // Step 5: Supplier withdraws (with earned interest)
+      // Actual withdrawal = 1000 * 1.025 = 1025
+      await handleWithdraw(
+        createWithdrawEvent({
+          withdrawer: supplier,
+          recipient: supplier,
+          amount: '1025000000000000000000',
+          scaledDecrease: supplyAmount,
+          totalSupply: DECIMALS.zero,
+          totalDebt: DECIMALS.zero,
+          utilization: DECIMALS.zero,
+          logIndex: 4,
+        }),
+        marketId
+      );
+
+      // Final state
+      await assertMarketState(marketId, {
+        totalSupplyScaled: '0',
+        totalDebtScaled: '0',
+      });
+
+      await assertPositionState(marketId, supplier, {
+        supplyScaled: '0',
+      });
+
+      // Verify all transactions were recorded
+      await assertRecordCount('transaction', 4); // supply, borrow, repay, withdraw
+      await assertRecordCount('interestAccrualEvent', 1);
+    });
+
+    it('handles multiple supply/borrow cycles from same users', async () => {
+      const user = ADDRESSES.userA;
+
+      // First supply
+      await handleSupply(
+        createSupplyEvent({
+          supplier: user,
+          recipient: user,
+          amount: DECIMALS.oneToken,
+          scaledAmount: DECIMALS.oneToken,
+          logIndex: 0,
+        }),
+        marketId
+      );
+
+      // Second supply (same user)
+      await handleSupply(
+        createSupplyEvent({
+          supplier: user,
+          recipient: user,
+          amount: DECIMALS.oneToken,
+          scaledAmount: DECIMALS.oneToken,
+          logIndex: 1,
+        }),
+        marketId
+      );
+
+      await assertPositionState(marketId, user, {
+        supplyScaled: '2000000000000000000', // 2 tokens
+      });
+
+      // Partial withdraw
+      await handleWithdraw(
+        createWithdrawEvent({
+          withdrawer: user,
+          recipient: user,
+          amount: DECIMALS.oneToken,
+          scaledDecrease: DECIMALS.oneToken,
+          logIndex: 2,
+        }),
+        marketId
+      );
+
+      await assertPositionState(marketId, user, {
+        supplyScaled: DECIMALS.oneToken, // 1 token remaining
+      });
+
+      // Verify transaction count
+      await assertRecordCount('transaction', 3);
+    });
+  });
+
+  describe('Interest accrual impact on positions', () => {
+    beforeEach(async () => {
+      await createTestMarket({
+        id: marketId,
+        borrowIndex: new Decimal('1'),
+        liquidityIndex: new Decimal('1'),
+      });
+    });
+
+    it('scaled amounts remain constant while actual values change with indices', async () => {
+      const user = ADDRESSES.userA;
+
+      // Supply 1000 tokens (scaled = actual when index = 1)
+      await handleSupply(
+        createSupplyEvent({
+          supplier: user,
+          recipient: user,
+          amount: DECIMALS.thousand,
+          scaledAmount: DECIMALS.thousand,
+          logIndex: 0,
+        }),
+        marketId
+      );
+
+      // Verify initial state
+      const position1 = await prisma.userPosition.findUnique({
+        where: { id: `${marketId}:${user}` },
+      });
+      expectDecimalEquals(position1!.supplyScaled, DECIMALS.thousand);
+
+      // Interest accrues: liquidityIndex goes from 1 to 1.1
+      await handleAccrueInterest(
+        createAccrueInterestEvent({
+          liquidityIndex: '1.1',
+          borrowIndex: '1.15',
+          logIndex: 1,
+        }),
+        marketId
+      );
+
+      // Position's scaled amount should NOT change
+      const position2 = await prisma.userPosition.findUnique({
+        where: { id: `${marketId}:${user}` },
+      });
+      expectDecimalEquals(position2!.supplyScaled, DECIMALS.thousand);
+
+      // But the actual value (scaled * index) is now 1100
+      const market = await prisma.market.findUnique({ where: { id: marketId } });
+      const actualValue = new Decimal(position2!.supplyScaled.toString()).mul(
+        market!.liquidityIndex
+      );
+      expectDecimalEquals(actualValue, '1100000000000000000000');
+    });
+  });
+
+  describe('Edge cases in lending flow', () => {
+    beforeEach(async () => {
+      await createTestMarket({ id: marketId });
+    });
+
+    it('handles supply and immediate full withdrawal', async () => {
+      const user = ADDRESSES.userA;
+
+      await handleSupply(
+        createSupplyEvent({
+          supplier: user,
+          recipient: user,
+          amount: DECIMALS.oneToken,
+          scaledAmount: DECIMALS.oneToken,
+          logIndex: 0,
+        }),
+        marketId
+      );
+
+      await handleWithdraw(
+        createWithdrawEvent({
+          withdrawer: user,
+          recipient: user,
+          amount: DECIMALS.oneToken,
+          scaledDecrease: DECIMALS.oneToken,
+          logIndex: 1,
+        }),
+        marketId
+      );
+
+      await assertPositionState(marketId, user, {
+        supplyScaled: '0',
+      });
+
+      await assertMarketState(marketId, {
+        totalSupplyScaled: '0',
+      });
+    });
+
+    it('handles borrow and immediate full repayment', async () => {
+      // First, someone needs to supply
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: DECIMALS.thousand,
+          scaledAmount: DECIMALS.thousand,
+          logIndex: 0,
+        }),
+        marketId
+      );
+
+      const borrower = ADDRESSES.userB;
+
+      await handleBorrow(
+        createBorrowEvent({
+          borrower,
+          recipient: borrower,
+          amount: DECIMALS.oneToken,
+          scaledAmount: DECIMALS.oneToken,
+          logIndex: 1,
+        }),
+        marketId
+      );
+
+      await handleRepay(
+        createRepayEvent({
+          repayer: borrower,
+          borrower,
+          amount: DECIMALS.oneToken,
+          scaledDecrease: DECIMALS.oneToken,
+          logIndex: 2,
+        }),
+        marketId
+      );
+
+      await assertPositionState(marketId, borrower, {
+        debtScaled: '0',
+      });
+    });
+
+    it('handles third party repayment', async () => {
+      // Supply liquidity
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: DECIMALS.thousand,
+          scaledAmount: DECIMALS.thousand,
+          logIndex: 0,
+        }),
+        marketId
+      );
+
+      // UserB borrows
+      await handleBorrow(
+        createBorrowEvent({
+          borrower: ADDRESSES.userB,
+          recipient: ADDRESSES.userB,
+          amount: DECIMALS.oneToken,
+          scaledAmount: DECIMALS.oneToken,
+          logIndex: 1,
+        }),
+        marketId
+      );
+
+      // UserC repays on behalf of UserB
+      await handleRepay(
+        createRepayEvent({
+          repayer: ADDRESSES.userC, // Third party repayer
+          borrower: ADDRESSES.userB, // Original borrower
+          amount: DECIMALS.oneToken,
+          scaledDecrease: DECIMALS.oneToken,
+          logIndex: 2,
+        }),
+        marketId
+      );
+
+      // UserB's debt should be cleared
+      await assertPositionState(marketId, ADDRESSES.userB, {
+        debtScaled: '0',
+      });
+
+      // UserC should have no position
+      await assertPositionState(marketId, ADDRESSES.userC, { exists: false });
+
+      // Transaction should record userC as the actor
+      const tx = await prisma.transaction.findMany({
+        where: { action: 'REPAY' },
+      });
+      expect(tx[0].userAddress).toBe(ADDRESSES.userC);
+    });
+  });
+});

--- a/indexer/tests/scenarios/liquidation-flow.test.ts
+++ b/indexer/tests/scenarios/liquidation-flow.test.ts
@@ -1,0 +1,438 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Decimal } from 'decimal.js';
+import {
+  handleSupplyCollateral,
+  handleBorrow,
+  handleAccrueInterest,
+  handleLiquidate,
+} from '../../src/events/handlers';
+import { prisma } from '../../src/db/client';
+import {
+  ADDRESSES,
+  DECIMALS,
+  createTestMarket,
+  createSupplyCollateralEvent,
+  createBorrowEvent,
+  createAccrueInterestEvent,
+  createLiquidateEvent,
+  assertMarketState,
+  assertPositionState,
+  assertRecordCount,
+} from '../helpers';
+
+describe('Liquidation Flow Scenarios', () => {
+  const marketId = '1';
+
+  describe('Complete liquidation flow', () => {
+    beforeEach(async () => {
+      await createTestMarket({
+        id: marketId,
+        totalSupplyScaled: new Decimal(DECIMALS.million), // Existing liquidity
+      });
+    });
+
+    it('full liquidation flow: Collateral -> Borrow -> Interest -> Liquidation', async () => {
+      const borrower = ADDRESSES.userA;
+      const liquidator = ADDRESSES.liquidator;
+
+      // Step 1: Borrower supplies collateral (1000 ETH)
+      const collateralAmount = DECIMALS.thousand;
+      await handleSupplyCollateral(
+        createSupplyCollateralEvent({
+          supplier: borrower,
+          recipient: borrower,
+          amount: collateralAmount,
+          logIndex: 0,
+        }),
+        marketId
+      );
+
+      await assertPositionState(marketId, borrower, {
+        collateral: collateralAmount,
+        debtScaled: '0',
+      });
+
+      await assertMarketState(marketId, {
+        totalCollateral: collateralAmount,
+      });
+
+      // Step 2: Borrower takes a loan (800 USDC at 80% LTV)
+      const borrowAmount = '800000000000000000000'; // 800 tokens
+      await handleBorrow(
+        createBorrowEvent({
+          borrower,
+          recipient: borrower,
+          amount: borrowAmount,
+          scaledAmount: borrowAmount,
+          totalSupply: DECIMALS.million,
+          totalDebt: borrowAmount,
+          logIndex: 1,
+        }),
+        marketId
+      );
+
+      await assertPositionState(marketId, borrower, {
+        collateral: collateralAmount,
+        debtScaled: borrowAmount,
+      });
+
+      // Step 3: Interest accrues significantly (simulate time passing)
+      // Borrow index increases from 1 to 1.2 (20% interest)
+      // This makes actual debt = 800 * 1.2 = 960
+      // If collateral price dropped or stayed same, position is now undercollateralized
+      await handleAccrueInterest(
+        createAccrueInterestEvent({
+          borrowIndex: '1.2',
+          liquidityIndex: '1.1',
+          borrowRate: '0.2',
+          liquidityRate: '0.1',
+          logIndex: 2,
+        }),
+        marketId
+      );
+
+      // Step 4: Liquidator liquidates the position
+      // Repays 400 debt (50% close factor), seizes collateral with bonus
+      const debtRepaid = '400000000000000000000'; // 400 actual debt
+      const scaledDebtDecrease = '333333333333333333333'; // 400 / 1.2 = 333.33 scaled
+      const collateralSeized = '440000000000000000000'; // 400 + 10% bonus = 440
+
+      const remainingCollateral = new Decimal(collateralAmount)
+        .sub(collateralSeized)
+        .toString();
+
+      await handleLiquidate(
+        createLiquidateEvent({
+          liquidator,
+          borrower,
+          debtRepaid,
+          scaledDebtDecrease,
+          collateralSeized,
+          protocolFee: '40000000000000000000', // 10% of seized = 40
+          totalSupply: DECIMALS.million,
+          totalDebt: '560000000000000000000', // Remaining debt
+          totalCollateral: remainingCollateral,
+          logIndex: 3,
+        }),
+        marketId
+      );
+
+      // Verify borrower position after liquidation
+      const expectedDebtRemaining = new Decimal(borrowAmount)
+        .sub(scaledDebtDecrease)
+        .toString();
+
+      await assertPositionState(marketId, borrower, {
+        collateral: remainingCollateral,
+        debtScaled: expectedDebtRemaining,
+      });
+
+      // Verify market state
+      await assertMarketState(marketId, {
+        totalCollateral: remainingCollateral,
+      });
+
+      // Verify transaction records
+      await assertRecordCount('transaction', 3); // collateral, borrow, liquidate
+      await assertRecordCount('interestAccrualEvent', 1);
+
+      // Verify liquidation transaction details
+      const liquidateTx = await prisma.transaction.findFirst({
+        where: { action: 'LIQUIDATE' },
+      });
+
+      expect(liquidateTx).not.toBeNull();
+      expect(liquidateTx!.userAddress).toBe(liquidator);
+      expect(liquidateTx!.liquidator).toBe(liquidator);
+      expect(liquidateTx!.borrower).toBe(borrower);
+      expect(liquidateTx!.debtRepaid?.toString()).toBe(debtRepaid);
+      expect(liquidateTx!.collateralSeized?.toString()).toBe(collateralSeized);
+      expect(liquidateTx!.protocolFee?.toString()).toBe('40000000000000000000');
+    });
+
+    it('handles full position liquidation (100% close factor scenario)', async () => {
+      const borrower = ADDRESSES.userA;
+      const liquidator = ADDRESSES.liquidator;
+
+      // Supply collateral
+      await handleSupplyCollateral(
+        createSupplyCollateralEvent({
+          supplier: borrower,
+          recipient: borrower,
+          amount: DECIMALS.oneToken,
+          logIndex: 0,
+        }),
+        marketId
+      );
+
+      // Borrow against collateral
+      await handleBorrow(
+        createBorrowEvent({
+          borrower,
+          recipient: borrower,
+          amount: DECIMALS.oneToken,
+          scaledAmount: DECIMALS.oneToken,
+          logIndex: 1,
+        }),
+        marketId
+      );
+
+      // Full liquidation - all debt and collateral cleared
+      await handleLiquidate(
+        createLiquidateEvent({
+          liquidator,
+          borrower,
+          debtRepaid: DECIMALS.oneToken,
+          scaledDebtDecrease: DECIMALS.oneToken,
+          collateralSeized: DECIMALS.oneToken,
+          protocolFee: DECIMALS.dust,
+          totalCollateral: '0',
+          logIndex: 2,
+        }),
+        marketId
+      );
+
+      // Position should have zero debt and collateral
+      await assertPositionState(marketId, borrower, {
+        debtScaled: '0',
+        collateral: '0',
+      });
+
+      await assertMarketState(marketId, {
+        totalCollateral: '0',
+      });
+    });
+
+    it('handles partial liquidation preserving user position', async () => {
+      const borrower = ADDRESSES.userA;
+      const liquidator = ADDRESSES.liquidator;
+
+      // Supply 1000 collateral
+      await handleSupplyCollateral(
+        createSupplyCollateralEvent({
+          supplier: borrower,
+          recipient: borrower,
+          amount: DECIMALS.thousand,
+          logIndex: 0,
+        }),
+        marketId
+      );
+
+      // Borrow 500
+      const borrowAmount = '500000000000000000000';
+      await handleBorrow(
+        createBorrowEvent({
+          borrower,
+          recipient: borrower,
+          amount: borrowAmount,
+          scaledAmount: borrowAmount,
+          logIndex: 1,
+        }),
+        marketId
+      );
+
+      // Partial liquidation - repay 100, seize 110 (10% bonus)
+      const debtRepaid = '100000000000000000000';
+      const collateralSeized = '110000000000000000000';
+
+      await handleLiquidate(
+        createLiquidateEvent({
+          liquidator,
+          borrower,
+          debtRepaid,
+          scaledDebtDecrease: debtRepaid,
+          collateralSeized,
+          protocolFee: '10000000000000000000',
+          totalCollateral: '890000000000000000000', // 1000 - 110
+          logIndex: 2,
+        }),
+        marketId
+      );
+
+      // Position should still have remaining debt and collateral
+      await assertPositionState(marketId, borrower, {
+        debtScaled: '400000000000000000000', // 500 - 100
+        collateral: '890000000000000000000', // 1000 - 110
+      });
+    });
+  });
+
+  describe('Multiple liquidations on same position', () => {
+    beforeEach(async () => {
+      await createTestMarket({
+        id: marketId,
+        totalSupplyScaled: new Decimal(DECIMALS.million),
+      });
+    });
+
+    it('handles sequential liquidations on same borrower', async () => {
+      const borrower = ADDRESSES.userA;
+      const liquidator1 = ADDRESSES.liquidator;
+      const liquidator2 = ADDRESSES.userB;
+
+      // Setup: collateral and borrow
+      await handleSupplyCollateral(
+        createSupplyCollateralEvent({
+          supplier: borrower,
+          recipient: borrower,
+          amount: DECIMALS.thousand,
+          logIndex: 0,
+        }),
+        marketId
+      );
+
+      await handleBorrow(
+        createBorrowEvent({
+          borrower,
+          recipient: borrower,
+          amount: '500000000000000000000',
+          scaledAmount: '500000000000000000000',
+          logIndex: 1,
+        }),
+        marketId
+      );
+
+      // First liquidation by liquidator1
+      await handleLiquidate(
+        createLiquidateEvent({
+          liquidator: liquidator1,
+          borrower,
+          debtRepaid: '100000000000000000000',
+          scaledDebtDecrease: '100000000000000000000',
+          collateralSeized: '110000000000000000000',
+          protocolFee: '10000000000000000000',
+          totalCollateral: '890000000000000000000',
+          logIndex: 2,
+        }),
+        marketId
+      );
+
+      // Second liquidation by liquidator2
+      await handleLiquidate(
+        createLiquidateEvent({
+          liquidator: liquidator2,
+          borrower,
+          debtRepaid: '100000000000000000000',
+          scaledDebtDecrease: '100000000000000000000',
+          collateralSeized: '110000000000000000000',
+          protocolFee: '10000000000000000000',
+          totalCollateral: '780000000000000000000',
+          logIndex: 3,
+        }),
+        marketId
+      );
+
+      // Final position state
+      await assertPositionState(marketId, borrower, {
+        debtScaled: '300000000000000000000', // 500 - 100 - 100
+        collateral: '780000000000000000000', // 1000 - 110 - 110
+      });
+
+      // Two liquidation transactions
+      const liquidateTxs = await prisma.transaction.findMany({
+        where: { action: 'LIQUIDATE' },
+        orderBy: { timestamp: 'asc' },
+      });
+
+      expect(liquidateTxs).toHaveLength(2);
+      expect(liquidateTxs[0].liquidator).toBe(liquidator1);
+      expect(liquidateTxs[1].liquidator).toBe(liquidator2);
+    });
+  });
+
+  describe('Edge cases in liquidation', () => {
+    beforeEach(async () => {
+      await createTestMarket({
+        id: marketId,
+        totalSupplyScaled: new Decimal(DECIMALS.million),
+        totalCollateral: new Decimal(DECIMALS.thousand),
+      });
+    });
+
+    it('handles liquidation with zero protocol fee', async () => {
+      const borrower = ADDRESSES.userA;
+      const liquidator = ADDRESSES.liquidator;
+
+      await handleSupplyCollateral(
+        createSupplyCollateralEvent({
+          supplier: borrower,
+          recipient: borrower,
+          amount: DECIMALS.thousand,
+          logIndex: 0,
+        }),
+        marketId
+      );
+
+      await handleBorrow(
+        createBorrowEvent({
+          borrower,
+          recipient: borrower,
+          amount: DECIMALS.oneToken,
+          scaledAmount: DECIMALS.oneToken,
+          logIndex: 1,
+        }),
+        marketId
+      );
+
+      await handleLiquidate(
+        createLiquidateEvent({
+          liquidator,
+          borrower,
+          debtRepaid: DECIMALS.oneToken,
+          scaledDebtDecrease: DECIMALS.oneToken,
+          collateralSeized: DECIMALS.oneToken,
+          protocolFee: DECIMALS.zero, // No protocol fee
+          totalCollateral: '999000000000000000000',
+          logIndex: 2,
+        }),
+        marketId
+      );
+
+      const tx = await prisma.transaction.findFirst({
+        where: { action: 'LIQUIDATE' },
+      });
+
+      expect(tx!.protocolFee?.toString()).toBe('0');
+    });
+
+    it('preserves supplyScaled during liquidation', async () => {
+      const borrower = ADDRESSES.userA;
+
+      // User has both supply and collateral position
+      await prisma.userPosition.create({
+        data: {
+          id: `${marketId}:${borrower}`,
+          marketId,
+          userAddress: borrower,
+          supplyScaled: new Decimal(DECIMALS.thousand),
+          debtScaled: new Decimal('500000000000000000000'),
+          collateral: new Decimal(DECIMALS.thousand),
+          firstInteraction: new Date(),
+          lastInteraction: new Date(),
+        },
+      });
+
+      // Liquidate - should only affect debt and collateral
+      await handleLiquidate(
+        createLiquidateEvent({
+          liquidator: ADDRESSES.liquidator,
+          borrower,
+          debtRepaid: '100000000000000000000',
+          scaledDebtDecrease: '100000000000000000000',
+          collateralSeized: '110000000000000000000',
+          protocolFee: '10000000000000000000',
+          totalCollateral: '890000000000000000000',
+          logIndex: 0,
+        }),
+        marketId
+      );
+
+      // supplyScaled should be unchanged
+      await assertPositionState(marketId, borrower, {
+        supplyScaled: DECIMALS.thousand, // Unchanged
+        debtScaled: '400000000000000000000', // Reduced
+        collateral: '890000000000000000000', // Reduced
+      });
+    });
+  });
+});

--- a/indexer/tests/scenarios/multi-market.test.ts
+++ b/indexer/tests/scenarios/multi-market.test.ts
@@ -1,0 +1,493 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Decimal } from 'decimal.js';
+import {
+  handleSupply,
+  handleBorrow,
+  handleSupplyCollateral,
+  handleWithdraw,
+} from '../../src/events/handlers';
+import { prisma } from '../../src/db/client';
+import {
+  ADDRESSES,
+  DECIMALS,
+  createTestMarket,
+  createSupplyEvent,
+  createBorrowEvent,
+  createSupplyCollateralEvent,
+  createWithdrawEvent,
+  assertMarketState,
+  assertPositionState,
+  assertRecordCount,
+} from '../helpers';
+
+describe('Multi-Market Scenarios', () => {
+  const ethUsdcMarket = '1';
+  const btcUsdcMarket = '2';
+
+  describe('Single user across multiple markets', () => {
+    beforeEach(async () => {
+      await createTestMarket({
+        id: ethUsdcMarket,
+        marketAddress: ADDRESSES.market1,
+        collateralDenom: 'ueth',
+        debtDenom: 'uusdc',
+      });
+
+      await createTestMarket({
+        id: btcUsdcMarket,
+        marketAddress: ADDRESSES.market2,
+        collateralDenom: 'ubtc',
+        debtDenom: 'uusdc',
+      });
+    });
+
+    it('creates separate positions for same user in different markets', async () => {
+      const user = ADDRESSES.userA;
+
+      // Supply to ETH/USDC market
+      await handleSupply(
+        createSupplyEvent({
+          supplier: user,
+          recipient: user,
+          amount: DECIMALS.thousand,
+          scaledAmount: DECIMALS.thousand,
+          marketAddress: ADDRESSES.market1,
+          logIndex: 0,
+        }),
+        ethUsdcMarket
+      );
+
+      // Supply to BTC/USDC market
+      await handleSupply(
+        createSupplyEvent({
+          supplier: user,
+          recipient: user,
+          amount: '2000000000000000000000',
+          scaledAmount: '2000000000000000000000',
+          marketAddress: ADDRESSES.market2,
+          logIndex: 1,
+        }),
+        btcUsdcMarket
+      );
+
+      // Verify separate positions
+      await assertPositionState(ethUsdcMarket, user, {
+        supplyScaled: DECIMALS.thousand,
+      });
+
+      await assertPositionState(btcUsdcMarket, user, {
+        supplyScaled: '2000000000000000000000',
+      });
+
+      // Position IDs should be different
+      const positions = await prisma.userPosition.findMany({
+        where: { userAddress: user },
+      });
+
+      expect(positions).toHaveLength(2);
+      expect(positions.map((p) => p.id).sort()).toEqual([
+        `${ethUsdcMarket}:${user}`,
+        `${btcUsdcMarket}:${user}`,
+      ]);
+
+      // Markets should have independent totals
+      await assertMarketState(ethUsdcMarket, {
+        totalSupplyScaled: DECIMALS.thousand,
+      });
+
+      await assertMarketState(btcUsdcMarket, {
+        totalSupplyScaled: '2000000000000000000000',
+      });
+    });
+
+    it('handles different position types across markets', async () => {
+      const user = ADDRESSES.userA;
+
+      // Supply to ETH/USDC
+      await handleSupply(
+        createSupplyEvent({
+          supplier: user,
+          recipient: user,
+          amount: DECIMALS.thousand,
+          scaledAmount: DECIMALS.thousand,
+          marketAddress: ADDRESSES.market1,
+          logIndex: 0,
+        }),
+        ethUsdcMarket
+      );
+
+      // Supply collateral and borrow in BTC/USDC
+      await handleSupplyCollateral(
+        createSupplyCollateralEvent({
+          supplier: user,
+          recipient: user,
+          amount: '500000000000000000000',
+          marketAddress: ADDRESSES.market2,
+          logIndex: 1,
+        }),
+        btcUsdcMarket
+      );
+
+      await handleBorrow(
+        createBorrowEvent({
+          borrower: user,
+          recipient: user,
+          amount: '200000000000000000000',
+          scaledAmount: '200000000000000000000',
+          marketAddress: ADDRESSES.market2,
+          logIndex: 2,
+        }),
+        btcUsdcMarket
+      );
+
+      // ETH market: supply position
+      await assertPositionState(ethUsdcMarket, user, {
+        supplyScaled: DECIMALS.thousand,
+        debtScaled: '0',
+        collateral: '0',
+      });
+
+      // BTC market: collateral + borrow position
+      await assertPositionState(btcUsdcMarket, user, {
+        supplyScaled: '0',
+        debtScaled: '200000000000000000000',
+        collateral: '500000000000000000000',
+      });
+    });
+
+    it('operations in one market do not affect another', async () => {
+      const user = ADDRESSES.userA;
+
+      // Setup: supply in both markets
+      await handleSupply(
+        createSupplyEvent({
+          supplier: user,
+          recipient: user,
+          amount: DECIMALS.thousand,
+          scaledAmount: DECIMALS.thousand,
+          logIndex: 0,
+        }),
+        ethUsdcMarket
+      );
+
+      await handleSupply(
+        createSupplyEvent({
+          supplier: user,
+          recipient: user,
+          amount: DECIMALS.thousand,
+          scaledAmount: DECIMALS.thousand,
+          logIndex: 1,
+        }),
+        btcUsdcMarket
+      );
+
+      // Withdraw from ETH market only
+      await handleWithdraw(
+        createWithdrawEvent({
+          withdrawer: user,
+          recipient: user,
+          amount: '500000000000000000000',
+          scaledDecrease: '500000000000000000000',
+          logIndex: 2,
+        }),
+        ethUsdcMarket
+      );
+
+      // ETH market affected
+      await assertPositionState(ethUsdcMarket, user, {
+        supplyScaled: '500000000000000000000',
+      });
+
+      // BTC market unchanged
+      await assertPositionState(btcUsdcMarket, user, {
+        supplyScaled: DECIMALS.thousand,
+      });
+
+      // Market totals independent
+      await assertMarketState(ethUsdcMarket, {
+        totalSupplyScaled: '500000000000000000000',
+      });
+
+      await assertMarketState(btcUsdcMarket, {
+        totalSupplyScaled: DECIMALS.thousand,
+      });
+    });
+  });
+
+  describe('Multiple users across multiple markets', () => {
+    beforeEach(async () => {
+      await createTestMarket({
+        id: ethUsdcMarket,
+        marketAddress: ADDRESSES.market1,
+      });
+
+      await createTestMarket({
+        id: btcUsdcMarket,
+        marketAddress: ADDRESSES.market2,
+      });
+    });
+
+    it('tracks all user positions across all markets correctly', async () => {
+      // User A: supply in ETH market
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: '100000000000000000000',
+          scaledAmount: '100000000000000000000',
+          logIndex: 0,
+        }),
+        ethUsdcMarket
+      );
+
+      // User A: supply in BTC market
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: '200000000000000000000',
+          scaledAmount: '200000000000000000000',
+          logIndex: 1,
+        }),
+        btcUsdcMarket
+      );
+
+      // User B: supply in ETH market
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userB,
+          recipient: ADDRESSES.userB,
+          amount: '300000000000000000000',
+          scaledAmount: '300000000000000000000',
+          logIndex: 2,
+        }),
+        ethUsdcMarket
+      );
+
+      // User B: supply in BTC market
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userB,
+          recipient: ADDRESSES.userB,
+          amount: '400000000000000000000',
+          scaledAmount: '400000000000000000000',
+          logIndex: 3,
+        }),
+        btcUsdcMarket
+      );
+
+      // 4 total positions (2 users x 2 markets)
+      await assertRecordCount('userPosition', 4);
+
+      // Verify each position
+      await assertPositionState(ethUsdcMarket, ADDRESSES.userA, {
+        supplyScaled: '100000000000000000000',
+      });
+      await assertPositionState(btcUsdcMarket, ADDRESSES.userA, {
+        supplyScaled: '200000000000000000000',
+      });
+      await assertPositionState(ethUsdcMarket, ADDRESSES.userB, {
+        supplyScaled: '300000000000000000000',
+      });
+      await assertPositionState(btcUsdcMarket, ADDRESSES.userB, {
+        supplyScaled: '400000000000000000000',
+      });
+
+      // Market totals
+      await assertMarketState(ethUsdcMarket, {
+        totalSupplyScaled: '400000000000000000000', // 100 + 300
+      });
+      await assertMarketState(btcUsdcMarket, {
+        totalSupplyScaled: '600000000000000000000', // 200 + 400
+      });
+    });
+
+    it('handles cross-market user activity correctly', async () => {
+      // User A supplies to both markets
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: DECIMALS.thousand,
+          scaledAmount: DECIMALS.thousand,
+          logIndex: 0,
+        }),
+        ethUsdcMarket
+      );
+
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: DECIMALS.thousand,
+          scaledAmount: DECIMALS.thousand,
+          logIndex: 1,
+        }),
+        btcUsdcMarket
+      );
+
+      // User B borrows from ETH market (uses A's liquidity)
+      await handleSupplyCollateral(
+        createSupplyCollateralEvent({
+          supplier: ADDRESSES.userB,
+          recipient: ADDRESSES.userB,
+          amount: DECIMALS.thousand,
+          logIndex: 2,
+        }),
+        ethUsdcMarket
+      );
+
+      await handleBorrow(
+        createBorrowEvent({
+          borrower: ADDRESSES.userB,
+          recipient: ADDRESSES.userB,
+          amount: '500000000000000000000',
+          scaledAmount: '500000000000000000000',
+          logIndex: 3,
+        }),
+        ethUsdcMarket
+      );
+
+      // User B also operates in BTC market
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userB,
+          recipient: ADDRESSES.userB,
+          amount: '200000000000000000000',
+          scaledAmount: '200000000000000000000',
+          logIndex: 4,
+        }),
+        btcUsdcMarket
+      );
+
+      // Final positions
+      // ETH market: A supplies, B has collateral+debt
+      await assertPositionState(ethUsdcMarket, ADDRESSES.userA, {
+        supplyScaled: DECIMALS.thousand,
+        debtScaled: '0',
+        collateral: '0',
+      });
+      await assertPositionState(ethUsdcMarket, ADDRESSES.userB, {
+        supplyScaled: '0',
+        debtScaled: '500000000000000000000',
+        collateral: DECIMALS.thousand,
+      });
+
+      // BTC market: A supplies, B supplies
+      await assertPositionState(btcUsdcMarket, ADDRESSES.userA, {
+        supplyScaled: DECIMALS.thousand,
+      });
+      await assertPositionState(btcUsdcMarket, ADDRESSES.userB, {
+        supplyScaled: '200000000000000000000',
+      });
+
+      // Market summaries
+      await assertMarketState(ethUsdcMarket, {
+        totalSupplyScaled: DECIMALS.thousand,
+        totalDebtScaled: '500000000000000000000',
+        totalCollateral: DECIMALS.thousand,
+      });
+
+      await assertMarketState(btcUsdcMarket, {
+        totalSupplyScaled: '1200000000000000000000', // 1000 + 200
+        totalDebtScaled: '0',
+        totalCollateral: '0',
+      });
+    });
+  });
+
+  describe('Transaction tracking across markets', () => {
+    beforeEach(async () => {
+      await createTestMarket({
+        id: ethUsdcMarket,
+        marketAddress: ADDRESSES.market1,
+      });
+
+      await createTestMarket({
+        id: btcUsdcMarket,
+        marketAddress: ADDRESSES.market2,
+      });
+    });
+
+    it('transactions are correctly associated with their markets', async () => {
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: DECIMALS.oneToken,
+          scaledAmount: DECIMALS.oneToken,
+          txHash: 'ETH_TX_1',
+          logIndex: 0,
+        }),
+        ethUsdcMarket
+      );
+
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: DECIMALS.oneToken,
+          scaledAmount: DECIMALS.oneToken,
+          txHash: 'BTC_TX_1',
+          logIndex: 0,
+        }),
+        btcUsdcMarket
+      );
+
+      const ethTxs = await prisma.transaction.findMany({
+        where: { marketId: ethUsdcMarket },
+      });
+
+      const btcTxs = await prisma.transaction.findMany({
+        where: { marketId: btcUsdcMarket },
+      });
+
+      expect(ethTxs).toHaveLength(1);
+      expect(btcTxs).toHaveLength(1);
+      expect(ethTxs[0].txHash).toBe('ETH_TX_1');
+      expect(btcTxs[0].txHash).toBe('BTC_TX_1');
+    });
+
+    it('can query user transactions across all markets', async () => {
+      const user = ADDRESSES.userA;
+
+      await handleSupply(
+        createSupplyEvent({
+          supplier: user,
+          recipient: user,
+          logIndex: 0,
+        }),
+        ethUsdcMarket
+      );
+
+      await handleSupply(
+        createSupplyEvent({
+          supplier: user,
+          recipient: user,
+          logIndex: 1,
+        }),
+        btcUsdcMarket
+      );
+
+      await handleSupply(
+        createSupplyEvent({
+          supplier: user,
+          recipient: user,
+          logIndex: 2,
+        }),
+        ethUsdcMarket
+      );
+
+      // Query all transactions for user across markets
+      const userTxs = await prisma.transaction.findMany({
+        where: { userAddress: user },
+        orderBy: { timestamp: 'asc' },
+      });
+
+      expect(userTxs).toHaveLength(3);
+      expect(userTxs[0].marketId).toBe(ethUsdcMarket);
+      expect(userTxs[1].marketId).toBe(btcUsdcMarket);
+      expect(userTxs[2].marketId).toBe(ethUsdcMarket);
+    });
+  });
+});

--- a/indexer/tests/scenarios/multi-user.test.ts
+++ b/indexer/tests/scenarios/multi-user.test.ts
@@ -1,0 +1,453 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Decimal } from 'decimal.js';
+import {
+  handleSupply,
+  handleWithdraw,
+  handleBorrow,
+  handleRepay,
+  handleSupplyCollateral,
+} from '../../src/events/handlers';
+import { prisma } from '../../src/db/client';
+import {
+  ADDRESSES,
+  DECIMALS,
+  createTestMarket,
+  createSupplyEvent,
+  createWithdrawEvent,
+  createBorrowEvent,
+  createRepayEvent,
+  createSupplyCollateralEvent,
+  assertMarketState,
+  assertPositionState,
+  assertRecordCount,
+} from '../helpers';
+
+describe('Multi-User Scenarios', () => {
+  const marketId = '1';
+
+  describe('Multiple users interacting with same market', () => {
+    beforeEach(async () => {
+      await createTestMarket({ id: marketId });
+    });
+
+    it('tracks separate positions for multiple suppliers', async () => {
+      // User A supplies 1000
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: DECIMALS.thousand,
+          scaledAmount: DECIMALS.thousand,
+          totalSupply: DECIMALS.thousand,
+          logIndex: 0,
+        }),
+        marketId
+      );
+
+      // User B supplies 2000
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userB,
+          recipient: ADDRESSES.userB,
+          amount: '2000000000000000000000',
+          scaledAmount: '2000000000000000000000',
+          totalSupply: '3000000000000000000000',
+          logIndex: 1,
+        }),
+        marketId
+      );
+
+      // User C supplies 500
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userC,
+          recipient: ADDRESSES.userC,
+          amount: '500000000000000000000',
+          scaledAmount: '500000000000000000000',
+          totalSupply: '3500000000000000000000',
+          logIndex: 2,
+        }),
+        marketId
+      );
+
+      // Verify each position is independent
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        supplyScaled: DECIMALS.thousand,
+      });
+      await assertPositionState(marketId, ADDRESSES.userB, {
+        supplyScaled: '2000000000000000000000',
+      });
+      await assertPositionState(marketId, ADDRESSES.userC, {
+        supplyScaled: '500000000000000000000',
+      });
+
+      // Market totals should be sum of all
+      await assertMarketState(marketId, {
+        totalSupplyScaled: '3500000000000000000000',
+      });
+
+      // Three positions, three transactions
+      await assertRecordCount('userPosition', 3);
+      await assertRecordCount('transaction', 3);
+    });
+
+    it('handles mixed operations from multiple users', async () => {
+      // User A supplies 1000
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: DECIMALS.thousand,
+          scaledAmount: DECIMALS.thousand,
+          logIndex: 0,
+        }),
+        marketId
+      );
+
+      // User B supplies 1000
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userB,
+          recipient: ADDRESSES.userB,
+          amount: DECIMALS.thousand,
+          scaledAmount: DECIMALS.thousand,
+          logIndex: 1,
+        }),
+        marketId
+      );
+
+      // User C supplies collateral 1000
+      await handleSupplyCollateral(
+        createSupplyCollateralEvent({
+          supplier: ADDRESSES.userC,
+          recipient: ADDRESSES.userC,
+          amount: DECIMALS.thousand,
+          logIndex: 2,
+        }),
+        marketId
+      );
+
+      // User C borrows 500
+      await handleBorrow(
+        createBorrowEvent({
+          borrower: ADDRESSES.userC,
+          recipient: ADDRESSES.userC,
+          amount: '500000000000000000000',
+          scaledAmount: '500000000000000000000',
+          logIndex: 3,
+        }),
+        marketId
+      );
+
+      // User A withdraws 500
+      await handleWithdraw(
+        createWithdrawEvent({
+          withdrawer: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: '500000000000000000000',
+          scaledDecrease: '500000000000000000000',
+          logIndex: 4,
+        }),
+        marketId
+      );
+
+      // Verify final states
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        supplyScaled: '500000000000000000000',
+        debtScaled: '0',
+        collateral: '0',
+      });
+
+      await assertPositionState(marketId, ADDRESSES.userB, {
+        supplyScaled: DECIMALS.thousand,
+        debtScaled: '0',
+        collateral: '0',
+      });
+
+      await assertPositionState(marketId, ADDRESSES.userC, {
+        supplyScaled: '0',
+        debtScaled: '500000000000000000000',
+        collateral: DECIMALS.thousand,
+      });
+
+      // Market totals
+      await assertMarketState(marketId, {
+        totalSupplyScaled: '1500000000000000000000', // 500 + 1000
+        totalDebtScaled: '500000000000000000000',
+        totalCollateral: DECIMALS.thousand,
+      });
+    });
+
+    it('maintains correct totals after multiple withdrawals', async () => {
+      // Multiple users supply
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: DECIMALS.thousand,
+          scaledAmount: DECIMALS.thousand,
+          logIndex: 0,
+        }),
+        marketId
+      );
+
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userB,
+          recipient: ADDRESSES.userB,
+          amount: DECIMALS.thousand,
+          scaledAmount: DECIMALS.thousand,
+          logIndex: 1,
+        }),
+        marketId
+      );
+
+      // User A full withdrawal
+      await handleWithdraw(
+        createWithdrawEvent({
+          withdrawer: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: DECIMALS.thousand,
+          scaledDecrease: DECIMALS.thousand,
+          logIndex: 2,
+        }),
+        marketId
+      );
+
+      // User B partial withdrawal
+      await handleWithdraw(
+        createWithdrawEvent({
+          withdrawer: ADDRESSES.userB,
+          recipient: ADDRESSES.userB,
+          amount: '300000000000000000000',
+          scaledDecrease: '300000000000000000000',
+          logIndex: 3,
+        }),
+        marketId
+      );
+
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        supplyScaled: '0',
+      });
+
+      await assertPositionState(marketId, ADDRESSES.userB, {
+        supplyScaled: '700000000000000000000',
+      });
+
+      await assertMarketState(marketId, {
+        totalSupplyScaled: '700000000000000000000',
+      });
+    });
+  });
+
+  describe('User interactions with each other', () => {
+    beforeEach(async () => {
+      await createTestMarket({ id: marketId });
+    });
+
+    it('handles supply to different recipient', async () => {
+      // User A supplies but credits to User B
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userA,
+          recipient: ADDRESSES.userB, // Different recipient
+          amount: DECIMALS.thousand,
+          scaledAmount: DECIMALS.thousand,
+          logIndex: 0,
+        }),
+        marketId
+      );
+
+      // User A has no position
+      await assertPositionState(marketId, ADDRESSES.userA, { exists: false });
+
+      // User B has the position
+      await assertPositionState(marketId, ADDRESSES.userB, {
+        supplyScaled: DECIMALS.thousand,
+      });
+
+      // Transaction records User A as the actor
+      const tx = await prisma.transaction.findFirst({
+        where: { action: 'SUPPLY' },
+      });
+      expect(tx!.userAddress).toBe(ADDRESSES.userA);
+      expect(tx!.recipient).toBe(ADDRESSES.userB);
+    });
+
+    it('handles repay on behalf of another user', async () => {
+      // Setup: User A supplies, User B borrows
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: DECIMALS.thousand,
+          scaledAmount: DECIMALS.thousand,
+          logIndex: 0,
+        }),
+        marketId
+      );
+
+      await handleBorrow(
+        createBorrowEvent({
+          borrower: ADDRESSES.userB,
+          recipient: ADDRESSES.userB,
+          amount: '500000000000000000000',
+          scaledAmount: '500000000000000000000',
+          logIndex: 1,
+        }),
+        marketId
+      );
+
+      // User C repays User B's debt
+      await handleRepay(
+        createRepayEvent({
+          repayer: ADDRESSES.userC,
+          borrower: ADDRESSES.userB,
+          amount: '500000000000000000000',
+          scaledDecrease: '500000000000000000000',
+          logIndex: 2,
+        }),
+        marketId
+      );
+
+      // User B's debt is cleared
+      await assertPositionState(marketId, ADDRESSES.userB, {
+        debtScaled: '0',
+      });
+
+      // User C has no position (just repaid)
+      await assertPositionState(marketId, ADDRESSES.userC, { exists: false });
+    });
+  });
+
+  describe('Concurrent user activity simulation', () => {
+    beforeEach(async () => {
+      await createTestMarket({ id: marketId });
+    });
+
+    it('handles rapid sequential events from different users', async () => {
+      const users = [ADDRESSES.userA, ADDRESSES.userB, ADDRESSES.userC];
+
+      // Simulate 10 rapid supplies from different users
+      for (let i = 0; i < 10; i++) {
+        const user = users[i % 3];
+        await handleSupply(
+          createSupplyEvent({
+            supplier: user,
+            recipient: user,
+            amount: DECIMALS.oneToken,
+            scaledAmount: DECIMALS.oneToken,
+            logIndex: i,
+          }),
+          marketId
+        );
+      }
+
+      // Each user: A=4, B=3, C=3 supplies (indices 0,3,6,9 / 1,4,7 / 2,5,8)
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        supplyScaled: '4000000000000000000', // 4 tokens
+      });
+      await assertPositionState(marketId, ADDRESSES.userB, {
+        supplyScaled: '3000000000000000000', // 3 tokens
+      });
+      await assertPositionState(marketId, ADDRESSES.userC, {
+        supplyScaled: '3000000000000000000', // 3 tokens
+      });
+
+      // Total should be 10 tokens
+      await assertMarketState(marketId, {
+        totalSupplyScaled: '10000000000000000000',
+      });
+
+      // 10 transactions
+      await assertRecordCount('transaction', 10);
+    });
+
+    it('handles interleaved supply and withdraw from multiple users', async () => {
+      // Initial supplies
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: '100000000000000000000',
+          scaledAmount: '100000000000000000000',
+          logIndex: 0,
+        }),
+        marketId
+      );
+
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userB,
+          recipient: ADDRESSES.userB,
+          amount: '200000000000000000000',
+          scaledAmount: '200000000000000000000',
+          logIndex: 1,
+        }),
+        marketId
+      );
+
+      // A withdraws, B supplies more
+      await handleWithdraw(
+        createWithdrawEvent({
+          withdrawer: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: '50000000000000000000',
+          scaledDecrease: '50000000000000000000',
+          logIndex: 2,
+        }),
+        marketId
+      );
+
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userB,
+          recipient: ADDRESSES.userB,
+          amount: '100000000000000000000',
+          scaledAmount: '100000000000000000000',
+          logIndex: 3,
+        }),
+        marketId
+      );
+
+      // C joins
+      await handleSupply(
+        createSupplyEvent({
+          supplier: ADDRESSES.userC,
+          recipient: ADDRESSES.userC,
+          amount: '150000000000000000000',
+          scaledAmount: '150000000000000000000',
+          logIndex: 4,
+        }),
+        marketId
+      );
+
+      // A withdraws rest
+      await handleWithdraw(
+        createWithdrawEvent({
+          withdrawer: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: '50000000000000000000',
+          scaledDecrease: '50000000000000000000',
+          logIndex: 5,
+        }),
+        marketId
+      );
+
+      // Final state
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        supplyScaled: '0', // 100 - 50 - 50
+      });
+      await assertPositionState(marketId, ADDRESSES.userB, {
+        supplyScaled: '300000000000000000000', // 200 + 100
+      });
+      await assertPositionState(marketId, ADDRESSES.userC, {
+        supplyScaled: '150000000000000000000',
+      });
+
+      await assertMarketState(marketId, {
+        totalSupplyScaled: '450000000000000000000', // 0 + 300 + 150
+      });
+    });
+  });
+});

--- a/indexer/tests/setup.ts
+++ b/indexer/tests/setup.ts
@@ -1,0 +1,96 @@
+import { beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+// Set environment variables BEFORE any imports that use them
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgresql://josiahkendall@localhost:5432/stone_test';
+process.env.RPC_ENDPOINT = 'http://localhost:26657';
+process.env.CHAIN_ID = 'testing';
+process.env.FACTORY_ADDRESS = 'cosmos1factoryqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq';
+process.env.MARKET_CODE_ID = '1';
+process.env.LOG_LEVEL = 'error';
+
+// Mock the config module to avoid deployment result loading
+vi.mock('../src/config', () => ({
+  config: {
+    database: {
+      url: process.env.DATABASE_URL,
+    },
+    blockchain: {
+      rpcEndpoint: 'http://localhost:26657',
+      chainId: 'testing',
+    },
+    contracts: {
+      factoryAddress: 'cosmos1factoryqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq',
+      marketCodeId: '1',
+    },
+    indexer: {
+      startBlockHeight: 1,
+      batchSize: 100,
+      pollIntervalMs: 1000,
+    },
+    api: {
+      port: 4000,
+      enableSubscriptions: false,
+    },
+    logging: {
+      level: 'error',
+    },
+    oracle: {
+      endpoints: [],
+    },
+  },
+}));
+
+// Mock external blockchain clients globally
+vi.mock('../src/utils/blockchain', () => ({
+  getTendermintClient: vi.fn(),
+  getCosmWasmClient: vi.fn(),
+  queryMarketInfo: vi.fn(),
+}));
+
+// Mock subscriptions (no-op in tests)
+vi.mock('../src/api/resolvers/subscriptions', () => ({
+  publishMarketUpdate: vi.fn(),
+  publishTransaction: vi.fn(),
+  publishPositionUpdate: vi.fn(),
+}));
+
+// Mock logger to reduce noise in tests
+vi.mock('../src/utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Import prisma AFTER mocking config
+import { prisma } from '../src/db/client';
+
+beforeAll(async () => {
+  // Ensure database connection works
+  try {
+    await prisma.$executeRaw`SELECT 1`;
+  } catch (error) {
+    console.error('Database connection failed. Ensure PostgreSQL is running and DATABASE_URL is set.');
+    console.error('For tests, set: export DATABASE_URL="postgresql://localhost:5432/stone_test"');
+    throw error;
+  }
+});
+
+afterAll(async () => {
+  await prisma.$disconnect();
+});
+
+beforeEach(async () => {
+  // Clear all tables before each test in correct order (respecting foreign keys)
+  await prisma.interestAccrualEvent.deleteMany();
+  await prisma.marketSnapshot.deleteMany();
+  await prisma.transaction.deleteMany();
+  await prisma.userPosition.deleteMany();
+  await prisma.market.deleteMany();
+  await prisma.indexerState.deleteMany();
+
+  // Reset all mocks
+  vi.clearAllMocks();
+});

--- a/indexer/tests/unit/handlers/accrue-interest.test.ts
+++ b/indexer/tests/unit/handlers/accrue-interest.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Decimal } from 'decimal.js';
+import { handleAccrueInterest } from '../../../src/events/handlers';
+import { prisma } from '../../../src/db/client';
+import {
+  ADDRESSES,
+  createTestMarket,
+  createAccrueInterestEvent,
+  assertMarketState,
+  assertInterestAccrualCreated,
+  assertRecordCount,
+} from '../../helpers';
+
+describe('handleAccrueInterest', () => {
+  const marketId = '1';
+
+  beforeEach(async () => {
+    await createTestMarket({ id: marketId });
+  });
+
+  describe('happy path', () => {
+    it('updates market borrowIndex', async () => {
+      const event = createAccrueInterestEvent({
+        borrowIndex: '1.05',
+      });
+
+      await handleAccrueInterest(event, marketId);
+
+      await assertMarketState(marketId, {
+        borrowIndex: '1.05',
+      });
+    });
+
+    it('updates market liquidityIndex', async () => {
+      const event = createAccrueInterestEvent({
+        liquidityIndex: '1.03',
+      });
+
+      await handleAccrueInterest(event, marketId);
+
+      await assertMarketState(marketId, {
+        liquidityIndex: '1.03',
+      });
+    });
+
+    it('updates market borrowRate', async () => {
+      const event = createAccrueInterestEvent({
+        borrowRate: '0.08',
+      });
+
+      await handleAccrueInterest(event, marketId);
+
+      await assertMarketState(marketId, {
+        borrowRate: '0.08',
+      });
+    });
+
+    it('updates market liquidityRate', async () => {
+      const event = createAccrueInterestEvent({
+        liquidityRate: '0.04',
+      });
+
+      await handleAccrueInterest(event, marketId);
+
+      await assertMarketState(marketId, {
+        liquidityRate: '0.04',
+      });
+    });
+
+    it('updates all interest fields at once', async () => {
+      const event = createAccrueInterestEvent({
+        borrowIndex: '1.1',
+        liquidityIndex: '1.05',
+        borrowRate: '0.1',
+        liquidityRate: '0.06',
+      });
+
+      await handleAccrueInterest(event, marketId);
+
+      await assertMarketState(marketId, {
+        borrowIndex: '1.1',
+        liquidityIndex: '1.05',
+        borrowRate: '0.1',
+        liquidityRate: '0.06',
+      });
+    });
+
+    it('creates InterestAccrualEvent record', async () => {
+      const event = createAccrueInterestEvent({
+        borrowIndex: '1.05',
+        liquidityIndex: '1.03',
+        borrowRate: '0.05',
+        liquidityRate: '0.03',
+      });
+
+      await handleAccrueInterest(event, marketId);
+
+      await assertInterestAccrualCreated(event.txHash, event.logIndex, {
+        marketId,
+        borrowIndex: '1.05',
+        liquidityIndex: '1.03',
+        borrowRate: '0.05',
+        liquidityRate: '0.03',
+      });
+    });
+
+    it('does NOT create Transaction record', async () => {
+      const event = createAccrueInterestEvent();
+
+      await handleAccrueInterest(event, marketId);
+
+      // No transaction should be created for accrue_interest
+      await assertRecordCount('transaction', 0);
+
+      // But InterestAccrualEvent should exist
+      await assertRecordCount('interestAccrualEvent', 1);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles high precision decimal values', async () => {
+      const event = createAccrueInterestEvent({
+        borrowIndex: '1.123456789012345678',
+        liquidityIndex: '1.098765432109876543',
+      });
+
+      await handleAccrueInterest(event, marketId);
+
+      const market = await prisma.market.findUnique({ where: { id: marketId } });
+      // Should preserve precision up to 18 decimals
+      expect(market!.borrowIndex.toString()).toBe('1.123456789012345678');
+      expect(market!.liquidityIndex.toString()).toBe('1.098765432109876543');
+    });
+
+    it('handles indices greater than 2', async () => {
+      const event = createAccrueInterestEvent({
+        borrowIndex: '2.5',
+        liquidityIndex: '2.1',
+      });
+
+      await handleAccrueInterest(event, marketId);
+
+      await assertMarketState(marketId, {
+        borrowIndex: '2.5',
+        liquidityIndex: '2.1',
+      });
+    });
+
+    it('handles zero rates', async () => {
+      const event = createAccrueInterestEvent({
+        borrowRate: '0',
+        liquidityRate: '0',
+      });
+
+      await handleAccrueInterest(event, marketId);
+
+      await assertMarketState(marketId, {
+        borrowRate: '0',
+        liquidityRate: '0',
+      });
+    });
+
+    it('handles very high interest rates', async () => {
+      const event = createAccrueInterestEvent({
+        borrowRate: '1.5', // 150% APR
+        liquidityRate: '1.0', // 100% APR
+      });
+
+      await handleAccrueInterest(event, marketId);
+
+      await assertMarketState(marketId, {
+        borrowRate: '1.5',
+        liquidityRate: '1.0',
+      });
+    });
+
+    it('preserves other market state when updating indices', async () => {
+      // Create market with some state
+      await prisma.market.update({
+        where: { id: marketId },
+        data: {
+          totalSupplyScaled: new Decimal('1000000000000000000000'),
+          totalDebtScaled: new Decimal('500000000000000000000'),
+        },
+      });
+
+      const event = createAccrueInterestEvent({
+        borrowIndex: '1.1',
+        liquidityIndex: '1.05',
+      });
+
+      await handleAccrueInterest(event, marketId);
+
+      // Indices should be updated
+      await assertMarketState(marketId, {
+        borrowIndex: '1.1',
+        liquidityIndex: '1.05',
+        // These should be unchanged
+        totalSupplyScaled: '1000000000000000000000',
+        totalDebtScaled: '500000000000000000000',
+      });
+    });
+
+    it('updates lastUpdate timestamp', async () => {
+      const timestamp = Math.floor(Date.now() / 1000);
+      const event = createAccrueInterestEvent({
+        lastUpdate: String(timestamp),
+        timestamp,
+      });
+
+      await handleAccrueInterest(event, marketId);
+
+      const market = await prisma.market.findUnique({ where: { id: marketId } });
+      expect(Number(market!.lastUpdate)).toBe(timestamp);
+    });
+
+    it('records correct timestamp in InterestAccrualEvent', async () => {
+      const timestamp = 1700000000;
+      const event = createAccrueInterestEvent({
+        timestamp,
+      });
+
+      await handleAccrueInterest(event, marketId);
+
+      const accrualEvent = await prisma.interestAccrualEvent.findUnique({
+        where: { id: `${event.txHash}:${event.logIndex}` },
+      });
+
+      expect(accrualEvent!.timestamp.getTime()).toBe(timestamp * 1000);
+    });
+  });
+});

--- a/indexer/tests/unit/handlers/borrow.test.ts
+++ b/indexer/tests/unit/handlers/borrow.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Decimal } from 'decimal.js';
+import { handleBorrow } from '../../../src/events/handlers';
+import { prisma } from '../../../src/db/client';
+import {
+  ADDRESSES,
+  DECIMALS,
+  createTestMarket,
+  createTestPosition,
+  createBorrowEvent,
+  assertMarketState,
+  assertPositionState,
+  assertTransactionCreated,
+  expectDecimalEquals,
+} from '../../helpers';
+
+describe('handleBorrow', () => {
+  const marketId = '1';
+
+  beforeEach(async () => {
+    await createTestMarket({
+      id: marketId,
+      totalSupplyScaled: new Decimal(DECIMALS.thousand),
+    });
+  });
+
+  describe('happy path', () => {
+    it('increments totalDebtScaled on market', async () => {
+      const event = createBorrowEvent({
+        scaledAmount: DECIMALS.oneToken,
+      });
+
+      await handleBorrow(event, marketId);
+
+      await assertMarketState(marketId, {
+        totalDebtScaled: DECIMALS.oneToken,
+      });
+    });
+
+    it('creates new position with debt when user has no existing position', async () => {
+      const event = createBorrowEvent({
+        borrower: ADDRESSES.userA,
+        scaledAmount: DECIMALS.oneToken,
+      });
+
+      await handleBorrow(event, marketId);
+
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        supplyScaled: '0',
+        debtScaled: DECIMALS.oneToken,
+        collateral: '0',
+      });
+    });
+
+    it('increments existing position debtScaled', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        debtScaled: new Decimal(DECIMALS.oneToken),
+      });
+
+      const event = createBorrowEvent({
+        borrower: ADDRESSES.userA,
+        scaledAmount: DECIMALS.oneToken,
+      });
+
+      await handleBorrow(event, marketId);
+
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        debtScaled: '2000000000000000000',
+      });
+    });
+
+    it('creates transaction with action BORROW', async () => {
+      const event = createBorrowEvent({
+        borrower: ADDRESSES.userA,
+        recipient: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+        scaledAmount: DECIMALS.oneToken,
+      });
+
+      await handleBorrow(event, marketId);
+
+      await assertTransactionCreated(event.txHash, event.logIndex, {
+        action: 'BORROW',
+        marketId,
+        userAddress: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+        scaledAmount: DECIMALS.oneToken,
+        recipient: ADDRESSES.userA,
+      });
+    });
+
+    it('records market state snapshot in transaction', async () => {
+      const event = createBorrowEvent({
+        totalSupply: DECIMALS.thousand,
+        totalDebt: DECIMALS.oneToken,
+        utilization: DECIMALS.tenPercent,
+      });
+
+      await handleBorrow(event, marketId);
+
+      const tx = await prisma.transaction.findUnique({
+        where: { id: `${event.txHash}:${event.logIndex}` },
+      });
+
+      expectDecimalEquals(tx!.totalSupply, DECIMALS.thousand);
+      expectDecimalEquals(tx!.totalDebt, DECIMALS.oneToken);
+      expectDecimalEquals(tx!.utilization, DECIMALS.tenPercent);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles borrow to different recipient', async () => {
+      const event = createBorrowEvent({
+        borrower: ADDRESSES.userA,
+        recipient: ADDRESSES.userB,
+        scaledAmount: DECIMALS.oneToken,
+      });
+
+      await handleBorrow(event, marketId);
+
+      // Debt is recorded against borrower, not recipient
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        debtScaled: DECIMALS.oneToken,
+      });
+
+      // No position for recipient
+      await assertPositionState(marketId, ADDRESSES.userB, { exists: false });
+    });
+
+    it('preserves existing supplyScaled and collateral', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        supplyScaled: new Decimal(DECIMALS.thousand),
+        collateral: new Decimal(DECIMALS.oneToken),
+        debtScaled: new Decimal(0),
+      });
+
+      const event = createBorrowEvent({
+        borrower: ADDRESSES.userA,
+        scaledAmount: DECIMALS.oneToken,
+      });
+
+      await handleBorrow(event, marketId);
+
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        supplyScaled: DECIMALS.thousand,
+        collateral: DECIMALS.oneToken,
+        debtScaled: DECIMALS.oneToken,
+      });
+    });
+
+    it('handles large borrow amounts', async () => {
+      const largeAmount = '100000000000000000000000000000';
+
+      const event = createBorrowEvent({
+        amount: largeAmount,
+        scaledAmount: largeAmount,
+      });
+
+      await handleBorrow(event, marketId);
+
+      await assertMarketState(marketId, {
+        totalDebtScaled: largeAmount,
+      });
+    });
+
+    it('throws error when market not found', async () => {
+      const event = createBorrowEvent();
+
+      await expect(handleBorrow(event, 'non-existent')).rejects.toThrow(
+        'Market not found: non-existent'
+      );
+    });
+
+    it('updates lastInteraction timestamp', async () => {
+      const oldDate = new Date('2020-01-01');
+      await prisma.userPosition.create({
+        data: {
+          id: `${marketId}:${ADDRESSES.userA}`,
+          marketId,
+          userAddress: ADDRESSES.userA,
+          supplyScaled: new Decimal(0),
+          debtScaled: new Decimal(DECIMALS.oneToken),
+          collateral: new Decimal(0),
+          firstInteraction: oldDate,
+          lastInteraction: oldDate,
+        },
+      });
+
+      const event = createBorrowEvent({
+        borrower: ADDRESSES.userA,
+        timestamp: Math.floor(Date.now() / 1000),
+      });
+
+      await handleBorrow(event, marketId);
+
+      const position = await prisma.userPosition.findUnique({
+        where: { id: `${marketId}:${ADDRESSES.userA}` },
+      });
+
+      expect(position!.lastInteraction.getTime()).toBeGreaterThan(oldDate.getTime());
+    });
+  });
+});

--- a/indexer/tests/unit/handlers/liquidate.test.ts
+++ b/indexer/tests/unit/handlers/liquidate.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Decimal } from 'decimal.js';
+import { handleLiquidate } from '../../../src/events/handlers';
+import { prisma } from '../../../src/db/client';
+import {
+  ADDRESSES,
+  DECIMALS,
+  createTestMarket,
+  createTestPosition,
+  createLiquidateEvent,
+  assertMarketState,
+  assertPositionState,
+  assertTransactionCreated,
+  expectDecimalEquals,
+} from '../../helpers';
+
+describe('handleLiquidate', () => {
+  const marketId = '1';
+
+  beforeEach(async () => {
+    await createTestMarket({
+      id: marketId,
+      totalDebtScaled: new Decimal(DECIMALS.thousand),
+      totalCollateral: new Decimal(DECIMALS.thousand),
+    });
+  });
+
+  describe('happy path', () => {
+    it('decrements totalDebtScaled by scaledDebtDecrease', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        debtScaled: new Decimal(DECIMALS.thousand),
+        collateral: new Decimal(DECIMALS.thousand),
+      });
+
+      const event = createLiquidateEvent({
+        borrower: ADDRESSES.userA,
+        scaledDebtDecrease: DECIMALS.oneToken,
+        totalCollateral: '999000000000000000000', // After seizure
+      });
+
+      await handleLiquidate(event, marketId);
+
+      await assertMarketState(marketId, {
+        totalDebtScaled: '999000000000000000000',
+      });
+    });
+
+    it('sets totalCollateral from event (absolute value)', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        debtScaled: new Decimal(DECIMALS.thousand),
+        collateral: new Decimal(DECIMALS.thousand),
+      });
+
+      const newTotalCollateral = '500000000000000000000';
+      const event = createLiquidateEvent({
+        borrower: ADDRESSES.userA,
+        totalCollateral: newTotalCollateral,
+      });
+
+      await handleLiquidate(event, marketId);
+
+      await assertMarketState(marketId, {
+        totalCollateral: newTotalCollateral,
+      });
+    });
+
+    it('updates borrower position: reduces debt and collateral', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        debtScaled: new Decimal(DECIMALS.thousand),
+        collateral: new Decimal(DECIMALS.thousand),
+      });
+
+      const event = createLiquidateEvent({
+        borrower: ADDRESSES.userA,
+        scaledDebtDecrease: DECIMALS.oneToken,
+        collateralSeized: DECIMALS.oneToken,
+      });
+
+      await handleLiquidate(event, marketId);
+
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        debtScaled: '999000000000000000000',
+        collateral: '999000000000000000000',
+      });
+    });
+
+    it('creates transaction with all liquidation fields', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        debtScaled: new Decimal(DECIMALS.thousand),
+        collateral: new Decimal(DECIMALS.thousand),
+      });
+
+      const event = createLiquidateEvent({
+        liquidator: ADDRESSES.liquidator,
+        borrower: ADDRESSES.userA,
+        debtRepaid: DECIMALS.oneToken,
+        collateralSeized: DECIMALS.oneToken,
+        protocolFee: DECIMALS.dust,
+      });
+
+      await handleLiquidate(event, marketId);
+
+      await assertTransactionCreated(event.txHash, event.logIndex, {
+        action: 'LIQUIDATE',
+        marketId,
+        userAddress: ADDRESSES.liquidator, // Liquidator is the user
+        liquidator: ADDRESSES.liquidator,
+        borrower: ADDRESSES.userA,
+        debtRepaid: DECIMALS.oneToken,
+        collateralSeized: DECIMALS.oneToken,
+        protocolFee: DECIMALS.dust,
+      });
+    });
+
+    it('records market state snapshot in transaction', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        debtScaled: new Decimal(DECIMALS.thousand),
+        collateral: new Decimal(DECIMALS.thousand),
+      });
+
+      const event = createLiquidateEvent({
+        borrower: ADDRESSES.userA,
+        totalSupply: DECIMALS.thousand,
+        totalDebt: '999000000000000000000',
+        totalCollateral: '999000000000000000000',
+        utilization: DECIMALS.tenPercent,
+      });
+
+      await handleLiquidate(event, marketId);
+
+      const tx = await prisma.transaction.findUnique({
+        where: { id: `${event.txHash}:${event.logIndex}` },
+      });
+
+      expectDecimalEquals(tx!.totalSupply, DECIMALS.thousand);
+      expectDecimalEquals(tx!.totalDebt, '999000000000000000000');
+      expectDecimalEquals(tx!.totalCollateral, '999000000000000000000');
+      expectDecimalEquals(tx!.utilization, DECIMALS.tenPercent);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('does not create borrower position if none exists', async () => {
+      const event = createLiquidateEvent({
+        borrower: ADDRESSES.userA,
+        scaledDebtDecrease: DECIMALS.oneToken,
+        collateralSeized: DECIMALS.oneToken,
+        totalCollateral: '999000000000000000000',
+      });
+
+      await handleLiquidate(event, marketId);
+
+      // No position should be created
+      await assertPositionState(marketId, ADDRESSES.userA, { exists: false });
+
+      // Market should still be updated
+      await assertMarketState(marketId, {
+        totalDebtScaled: '999000000000000000000',
+        totalCollateral: '999000000000000000000',
+      });
+    });
+
+    it('handles full liquidation (debt and collateral to zero)', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        debtScaled: new Decimal(DECIMALS.oneToken),
+        collateral: new Decimal(DECIMALS.oneToken),
+      });
+
+      const event = createLiquidateEvent({
+        borrower: ADDRESSES.userA,
+        scaledDebtDecrease: DECIMALS.oneToken,
+        collateralSeized: DECIMALS.oneToken,
+        totalCollateral: '999000000000000000000',
+      });
+
+      await handleLiquidate(event, marketId);
+
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        debtScaled: '0',
+        collateral: '0',
+      });
+    });
+
+    it('preserves supplyScaled when liquidating', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        supplyScaled: new Decimal(DECIMALS.thousand),
+        debtScaled: new Decimal(DECIMALS.thousand),
+        collateral: new Decimal(DECIMALS.thousand),
+      });
+
+      const event = createLiquidateEvent({
+        borrower: ADDRESSES.userA,
+        scaledDebtDecrease: DECIMALS.oneToken,
+        collateralSeized: DECIMALS.oneToken,
+      });
+
+      await handleLiquidate(event, marketId);
+
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        supplyScaled: DECIMALS.thousand, // Unchanged
+        debtScaled: '999000000000000000000',
+        collateral: '999000000000000000000',
+      });
+    });
+
+    it('handles partial liquidation', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        debtScaled: new Decimal(DECIMALS.thousand),
+        collateral: new Decimal(DECIMALS.thousand),
+      });
+
+      // Liquidate 50%
+      const halfDebt = '500000000000000000000';
+      const halfCollateral = '500000000000000000000';
+      const event = createLiquidateEvent({
+        borrower: ADDRESSES.userA,
+        debtRepaid: halfDebt,
+        scaledDebtDecrease: halfDebt,
+        collateralSeized: halfCollateral,
+        totalCollateral: halfCollateral,
+      });
+
+      await handleLiquidate(event, marketId);
+
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        debtScaled: halfDebt,
+        collateral: halfCollateral,
+      });
+    });
+
+    it('throws error when market not found', async () => {
+      const event = createLiquidateEvent();
+
+      await expect(handleLiquidate(event, 'non-existent')).rejects.toThrow(
+        'Market not found: non-existent'
+      );
+    });
+
+    it('handles large protocol fee', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        debtScaled: new Decimal(DECIMALS.thousand),
+        collateral: new Decimal(DECIMALS.thousand),
+      });
+
+      const largeProtocolFee = '100000000000000000000'; // 100 tokens
+      const event = createLiquidateEvent({
+        borrower: ADDRESSES.userA,
+        protocolFee: largeProtocolFee,
+      });
+
+      await handleLiquidate(event, marketId);
+
+      const tx = await prisma.transaction.findUnique({
+        where: { id: `${event.txHash}:${event.logIndex}` },
+      });
+
+      expect(tx!.protocolFee?.toString()).toBe(largeProtocolFee);
+    });
+  });
+});

--- a/indexer/tests/unit/handlers/market-created.test.ts
+++ b/indexer/tests/unit/handlers/market-created.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleMarketCreated } from '../../../src/events/handlers';
+import { queryMarketInfo } from '../../../src/utils/blockchain';
+import { prisma } from '../../../src/db/client';
+import {
+  ADDRESSES,
+  createMarketCreatedEvent,
+  createMockMarketInfo,
+  assertRecordCount,
+  expectDecimalEquals,
+} from '../../helpers';
+
+// Get the mocked version
+const mockedQueryMarketInfo = vi.mocked(queryMarketInfo);
+
+describe('handleMarketCreated', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('happy path', () => {
+    it('calls queryMarketInfo with market address', async () => {
+      mockedQueryMarketInfo.mockResolvedValue(createMockMarketInfo());
+
+      const event = createMarketCreatedEvent({
+        marketAddress: ADDRESSES.market1,
+      });
+
+      await handleMarketCreated(event);
+
+      expect(mockedQueryMarketInfo).toHaveBeenCalledWith(ADDRESSES.market1);
+    });
+
+    it('creates Market with config fields from contract', async () => {
+      mockedQueryMarketInfo.mockResolvedValue(
+        createMockMarketInfo({
+          curator: ADDRESSES.curator,
+          collateralDenom: 'ueth',
+          debtDenom: 'uusdc',
+          oracle: ADDRESSES.oracle,
+        })
+      );
+
+      const event = createMarketCreatedEvent({
+        marketId: '1',
+        marketAddress: ADDRESSES.market1,
+      });
+
+      await handleMarketCreated(event);
+
+      const market = await prisma.market.findUnique({ where: { id: '1' } });
+      expect(market).not.toBeNull();
+      expect(market!.marketAddress).toBe(ADDRESSES.market1);
+      expect(market!.curator).toBe(ADDRESSES.curator);
+      expect(market!.collateralDenom).toBe('ueth');
+      expect(market!.debtDenom).toBe('uusdc');
+      expect(market!.oracle).toBe(ADDRESSES.oracle);
+    });
+
+    it('creates Market with params from contract', async () => {
+      mockedQueryMarketInfo.mockResolvedValue(
+        createMockMarketInfo({
+          params: {
+            loan_to_value: '0.75',
+            liquidation_threshold: '0.8',
+            liquidation_bonus: '0.1',
+            liquidation_protocol_fee: '0.2',
+            close_factor: '0.6',
+            interest_rate_model: { optimal_utilization: '0.9' },
+            protocol_fee: '0.15',
+            curator_fee: '0.1',
+            supply_cap: '1000000000000000000000000',
+            borrow_cap: '500000000000000000000000',
+            enabled: true,
+            is_mutable: false,
+          },
+        })
+      );
+
+      const event = createMarketCreatedEvent({
+        marketId: '1',
+      });
+
+      await handleMarketCreated(event);
+
+      const market = await prisma.market.findUnique({ where: { id: '1' } });
+      expectDecimalEquals(market!.loanToValue, '0.75');
+      expectDecimalEquals(market!.liquidationThreshold, '0.8');
+      expectDecimalEquals(market!.liquidationBonus, '0.1');
+      expectDecimalEquals(market!.liquidationProtocolFee, '0.2');
+      expectDecimalEquals(market!.closeFactor, '0.6');
+      expectDecimalEquals(market!.protocolFee, '0.15');
+      expectDecimalEquals(market!.curatorFee, '0.1');
+      expectDecimalEquals(market!.supplyCap, '1000000000000000000000000');
+      expectDecimalEquals(market!.borrowCap, '500000000000000000000000');
+      expect(market!.enabled).toBe(true);
+      expect(market!.isMutable).toBe(false);
+    });
+
+    it('stores interestRateModel as JSON', async () => {
+      const irm = {
+        optimal_utilization: '0.8',
+        base_rate: '0.02',
+        slope1: '0.04',
+        slope2: '0.75',
+      };
+
+      mockedQueryMarketInfo.mockResolvedValue(
+        createMockMarketInfo({
+          params: {
+            loan_to_value: '0.8',
+            liquidation_threshold: '0.85',
+            liquidation_bonus: '0.05',
+            liquidation_protocol_fee: '0.1',
+            close_factor: '0.5',
+            interest_rate_model: irm,
+            protocol_fee: '0.1',
+            curator_fee: '0.05',
+            supply_cap: null,
+            borrow_cap: null,
+            enabled: true,
+            is_mutable: true,
+          },
+        })
+      );
+
+      const event = createMarketCreatedEvent({ marketId: '1' });
+
+      await handleMarketCreated(event);
+
+      const market = await prisma.market.findUnique({ where: { id: '1' } });
+      expect(market!.interestRateModel).toEqual(irm);
+    });
+
+    it('initializes state fields with default values', async () => {
+      mockedQueryMarketInfo.mockResolvedValue(createMockMarketInfo());
+
+      const event = createMarketCreatedEvent({ marketId: '1' });
+
+      await handleMarketCreated(event);
+
+      const market = await prisma.market.findUnique({ where: { id: '1' } });
+      expectDecimalEquals(market!.borrowIndex, '1');
+      expectDecimalEquals(market!.liquidityIndex, '1');
+      expectDecimalEquals(market!.borrowRate, '0');
+      expectDecimalEquals(market!.liquidityRate, '0');
+      expectDecimalEquals(market!.totalSupplyScaled, '0');
+      expectDecimalEquals(market!.totalDebtScaled, '0');
+      expectDecimalEquals(market!.totalCollateral, '0');
+      expectDecimalEquals(market!.utilization, '0');
+      expectDecimalEquals(market!.availableLiquidity, '0');
+    });
+
+    it('sets createdAt and createdAtBlock from event', async () => {
+      mockedQueryMarketInfo.mockResolvedValue(createMockMarketInfo());
+
+      const timestamp = 1700000000;
+      const blockHeight = 12345;
+      const event = createMarketCreatedEvent({
+        marketId: '1',
+        timestamp,
+        blockHeight,
+      });
+
+      await handleMarketCreated(event);
+
+      const market = await prisma.market.findUnique({ where: { id: '1' } });
+      expect(market!.createdAt.getTime()).toBe(timestamp * 1000);
+      expect(Number(market!.createdAtBlock)).toBe(blockHeight);
+    });
+
+    it('sets lastUpdate from event timestamp', async () => {
+      mockedQueryMarketInfo.mockResolvedValue(createMockMarketInfo());
+
+      const timestamp = 1700000000;
+      const event = createMarketCreatedEvent({
+        marketId: '1',
+        timestamp,
+      });
+
+      await handleMarketCreated(event);
+
+      const market = await prisma.market.findUnique({ where: { id: '1' } });
+      expect(Number(market!.lastUpdate)).toBe(timestamp);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles null supply_cap from contract', async () => {
+      mockedQueryMarketInfo.mockResolvedValue(
+        createMockMarketInfo({
+          params: {
+            loan_to_value: '0.8',
+            liquidation_threshold: '0.85',
+            liquidation_bonus: '0.05',
+            liquidation_protocol_fee: '0.1',
+            close_factor: '0.5',
+            interest_rate_model: {},
+            protocol_fee: '0.1',
+            curator_fee: '0.05',
+            supply_cap: null,
+            borrow_cap: null,
+            enabled: true,
+            is_mutable: true,
+          },
+        })
+      );
+
+      const event = createMarketCreatedEvent({ marketId: '1' });
+
+      await handleMarketCreated(event);
+
+      const market = await prisma.market.findUnique({ where: { id: '1' } });
+      expect(market!.supplyCap).toBeNull();
+      expect(market!.borrowCap).toBeNull();
+    });
+
+    it('throws and logs error when queryMarketInfo fails', async () => {
+      mockedQueryMarketInfo.mockRejectedValue(new Error('Network error'));
+
+      const event = createMarketCreatedEvent({ marketId: '1' });
+
+      await expect(handleMarketCreated(event)).rejects.toThrow('Network error');
+
+      // No market should be created
+      await assertRecordCount('market', 0);
+    });
+
+    it('handles market with disabled state', async () => {
+      mockedQueryMarketInfo.mockResolvedValue(
+        createMockMarketInfo({
+          params: {
+            loan_to_value: '0.8',
+            liquidation_threshold: '0.85',
+            liquidation_bonus: '0.05',
+            liquidation_protocol_fee: '0.1',
+            close_factor: '0.5',
+            interest_rate_model: {},
+            protocol_fee: '0.1',
+            curator_fee: '0.05',
+            supply_cap: null,
+            borrow_cap: null,
+            enabled: false,
+            is_mutable: false,
+          },
+        })
+      );
+
+      const event = createMarketCreatedEvent({ marketId: '1' });
+
+      await handleMarketCreated(event);
+
+      const market = await prisma.market.findUnique({ where: { id: '1' } });
+      expect(market!.enabled).toBe(false);
+      expect(market!.isMutable).toBe(false);
+    });
+
+    it('creates unique markets with different IDs', async () => {
+      mockedQueryMarketInfo.mockResolvedValue(createMockMarketInfo());
+
+      const event1 = createMarketCreatedEvent({
+        marketId: '1',
+        marketAddress: ADDRESSES.market1,
+      });
+      const event2 = createMarketCreatedEvent({
+        marketId: '2',
+        marketAddress: ADDRESSES.market2,
+      });
+
+      await handleMarketCreated(event1);
+      await handleMarketCreated(event2);
+
+      await assertRecordCount('market', 2);
+
+      const market1 = await prisma.market.findUnique({ where: { id: '1' } });
+      const market2 = await prisma.market.findUnique({ where: { id: '2' } });
+      expect(market1!.marketAddress).toBe(ADDRESSES.market1);
+      expect(market2!.marketAddress).toBe(ADDRESSES.market2);
+    });
+  });
+});

--- a/indexer/tests/unit/handlers/repay.test.ts
+++ b/indexer/tests/unit/handlers/repay.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Decimal } from 'decimal.js';
+import { handleRepay } from '../../../src/events/handlers';
+import { prisma } from '../../../src/db/client';
+import {
+  ADDRESSES,
+  DECIMALS,
+  createTestMarket,
+  createTestPosition,
+  createRepayEvent,
+  assertMarketState,
+  assertPositionState,
+  assertTransactionCreated,
+  expectDecimalEquals,
+} from '../../helpers';
+
+describe('handleRepay', () => {
+  const marketId = '1';
+
+  beforeEach(async () => {
+    await createTestMarket({
+      id: marketId,
+      totalDebtScaled: new Decimal(DECIMALS.thousand),
+    });
+  });
+
+  describe('happy path', () => {
+    it('decrements totalDebtScaled on market', async () => {
+      const event = createRepayEvent({
+        scaledDecrease: DECIMALS.oneToken,
+      });
+
+      await handleRepay(event, marketId);
+
+      await assertMarketState(marketId, {
+        totalDebtScaled: '999000000000000000000',
+      });
+    });
+
+    it('decrements existing position debtScaled', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        debtScaled: new Decimal(DECIMALS.thousand),
+      });
+
+      const event = createRepayEvent({
+        borrower: ADDRESSES.userA,
+        scaledDecrease: DECIMALS.oneToken,
+      });
+
+      await handleRepay(event, marketId);
+
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        debtScaled: '999000000000000000000',
+      });
+    });
+
+    it('creates transaction with repayer as userAddress', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        debtScaled: new Decimal(DECIMALS.thousand),
+      });
+
+      const event = createRepayEvent({
+        repayer: ADDRESSES.userB,
+        borrower: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+        scaledDecrease: DECIMALS.oneToken,
+      });
+
+      await handleRepay(event, marketId);
+
+      await assertTransactionCreated(event.txHash, event.logIndex, {
+        action: 'REPAY',
+        marketId,
+        userAddress: ADDRESSES.userB, // Repayer, not borrower
+        amount: DECIMALS.oneToken,
+        scaledAmount: DECIMALS.oneToken,
+      });
+    });
+
+    it('records market state snapshot in transaction', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        debtScaled: new Decimal(DECIMALS.thousand),
+      });
+
+      const event = createRepayEvent({
+        borrower: ADDRESSES.userA,
+        totalSupply: DECIMALS.thousand,
+        totalDebt: DECIMALS.zero,
+        utilization: DECIMALS.zero,
+      });
+
+      await handleRepay(event, marketId);
+
+      const tx = await prisma.transaction.findUnique({
+        where: { id: `${event.txHash}:${event.logIndex}` },
+      });
+
+      expectDecimalEquals(tx!.totalSupply, DECIMALS.thousand);
+      expectDecimalEquals(tx!.totalDebt, DECIMALS.zero);
+      expectDecimalEquals(tx!.utilization, DECIMALS.zero);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('uses Decimal.max to prevent negative debt on position', async () => {
+      // Create position with small debt
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        debtScaled: new Decimal(DECIMALS.dust), // 1 wei
+      });
+
+      // Repay more than the debt (can happen due to rounding)
+      const event = createRepayEvent({
+        borrower: ADDRESSES.userA,
+        scaledDecrease: DECIMALS.oneToken, // Much larger than debt
+      });
+
+      await handleRepay(event, marketId);
+
+      // Position debt should be clamped to 0, not negative
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        debtScaled: '0',
+      });
+    });
+
+    it('allows repaying on behalf of another user', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        debtScaled: new Decimal(DECIMALS.thousand),
+      });
+
+      const event = createRepayEvent({
+        repayer: ADDRESSES.userB,
+        borrower: ADDRESSES.userA,
+        scaledDecrease: DECIMALS.oneToken,
+      });
+
+      await handleRepay(event, marketId);
+
+      // Borrower's debt is reduced
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        debtScaled: '999000000000000000000',
+      });
+
+      // No position for repayer
+      await assertPositionState(marketId, ADDRESSES.userB, { exists: false });
+    });
+
+    it('does not create position if none exists for borrower', async () => {
+      const event = createRepayEvent({
+        repayer: ADDRESSES.userB,
+        borrower: ADDRESSES.userA,
+        scaledDecrease: DECIMALS.oneToken,
+      });
+
+      await handleRepay(event, marketId);
+
+      // No position should be created
+      await assertPositionState(marketId, ADDRESSES.userA, { exists: false });
+
+      // Market should still be updated
+      await assertMarketState(marketId, {
+        totalDebtScaled: '999000000000000000000',
+      });
+    });
+
+    it('allows repaying to zero debt', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        debtScaled: new Decimal(DECIMALS.oneToken),
+      });
+
+      const event = createRepayEvent({
+        borrower: ADDRESSES.userA,
+        scaledDecrease: DECIMALS.oneToken,
+      });
+
+      await handleRepay(event, marketId);
+
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        debtScaled: '0',
+      });
+    });
+
+    it('preserves supplyScaled and collateral when repaying', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        supplyScaled: new Decimal(DECIMALS.thousand),
+        collateral: new Decimal(DECIMALS.oneToken),
+        debtScaled: new Decimal(DECIMALS.thousand),
+      });
+
+      const event = createRepayEvent({
+        borrower: ADDRESSES.userA,
+        scaledDecrease: DECIMALS.oneToken,
+      });
+
+      await handleRepay(event, marketId);
+
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        supplyScaled: DECIMALS.thousand,
+        collateral: DECIMALS.oneToken,
+        debtScaled: '999000000000000000000',
+      });
+    });
+
+    it('throws error when market not found', async () => {
+      const event = createRepayEvent();
+
+      await expect(handleRepay(event, 'non-existent')).rejects.toThrow(
+        'Market not found: non-existent'
+      );
+    });
+  });
+});

--- a/indexer/tests/unit/handlers/supply-collateral.test.ts
+++ b/indexer/tests/unit/handlers/supply-collateral.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Decimal } from 'decimal.js';
+import { handleSupplyCollateral } from '../../../src/events/handlers';
+import { prisma } from '../../../src/db/client';
+import {
+  ADDRESSES,
+  DECIMALS,
+  createTestMarket,
+  createTestPosition,
+  createSupplyCollateralEvent,
+  assertMarketState,
+  assertPositionState,
+  assertTransactionCreated,
+} from '../../helpers';
+
+describe('handleSupplyCollateral', () => {
+  const marketId = '1';
+
+  beforeEach(async () => {
+    await createTestMarket({ id: marketId });
+  });
+
+  describe('happy path', () => {
+    it('increments totalCollateral on market', async () => {
+      const event = createSupplyCollateralEvent({
+        amount: DECIMALS.oneToken,
+      });
+
+      await handleSupplyCollateral(event, marketId);
+
+      await assertMarketState(marketId, {
+        totalCollateral: DECIMALS.oneToken,
+      });
+    });
+
+    it('creates new position with only collateral (no supply/debt)', async () => {
+      const event = createSupplyCollateralEvent({
+        supplier: ADDRESSES.userA,
+        recipient: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+      });
+
+      await handleSupplyCollateral(event, marketId);
+
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        supplyScaled: '0',
+        debtScaled: '0',
+        collateral: DECIMALS.oneToken,
+      });
+    });
+
+    it('increments existing position collateral', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        collateral: new Decimal(DECIMALS.oneToken),
+      });
+
+      const event = createSupplyCollateralEvent({
+        supplier: ADDRESSES.userA,
+        recipient: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+      });
+
+      await handleSupplyCollateral(event, marketId);
+
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        collateral: '2000000000000000000',
+      });
+    });
+
+    it('creates transaction with totalCollateral snapshot', async () => {
+      const event = createSupplyCollateralEvent({
+        supplier: ADDRESSES.userA,
+        recipient: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+      });
+
+      await handleSupplyCollateral(event, marketId);
+
+      const tx = await prisma.transaction.findUnique({
+        where: { id: `${event.txHash}:${event.logIndex}` },
+      });
+
+      expect(tx!.action).toBe('SUPPLY_COLLATERAL');
+      expect(tx!.totalCollateral?.toString()).toBe(DECIMALS.oneToken);
+    });
+
+    it('preserves existing supplyScaled and debtScaled when updating collateral', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        supplyScaled: new Decimal(DECIMALS.thousand),
+        debtScaled: new Decimal(DECIMALS.oneToken),
+        collateral: new Decimal(DECIMALS.oneToken),
+      });
+
+      const event = createSupplyCollateralEvent({
+        supplier: ADDRESSES.userA,
+        recipient: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+      });
+
+      await handleSupplyCollateral(event, marketId);
+
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        supplyScaled: DECIMALS.thousand,
+        debtScaled: DECIMALS.oneToken,
+        collateral: '2000000000000000000',
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles supply collateral to different recipient', async () => {
+      const event = createSupplyCollateralEvent({
+        supplier: ADDRESSES.userA,
+        recipient: ADDRESSES.userB,
+        amount: DECIMALS.oneToken,
+      });
+
+      await handleSupplyCollateral(event, marketId);
+
+      // Position created for recipient
+      await assertPositionState(marketId, ADDRESSES.userB, {
+        collateral: DECIMALS.oneToken,
+      });
+
+      // No position for supplier
+      await assertPositionState(marketId, ADDRESSES.userA, { exists: false });
+
+      // Transaction userAddress is supplier
+      await assertTransactionCreated(event.txHash, event.logIndex, {
+        action: 'SUPPLY_COLLATERAL',
+        marketId,
+        userAddress: ADDRESSES.userA,
+        recipient: ADDRESSES.userB,
+      });
+    });
+
+    it('handles zero amount', async () => {
+      const event = createSupplyCollateralEvent({
+        amount: DECIMALS.zero,
+      });
+
+      await handleSupplyCollateral(event, marketId);
+
+      await assertMarketState(marketId, {
+        totalCollateral: '0',
+      });
+    });
+
+    it('handles large amounts', async () => {
+      const largeAmount = '100000000000000000000000000000';
+
+      const event = createSupplyCollateralEvent({
+        amount: largeAmount,
+      });
+
+      await handleSupplyCollateral(event, marketId);
+
+      await assertMarketState(marketId, {
+        totalCollateral: largeAmount,
+      });
+    });
+  });
+});

--- a/indexer/tests/unit/handlers/supply.test.ts
+++ b/indexer/tests/unit/handlers/supply.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Decimal } from 'decimal.js';
+import { handleSupply } from '../../../src/events/handlers';
+import { prisma } from '../../../src/db/client';
+import {
+  ADDRESSES,
+  DECIMALS,
+  createTestMarket,
+  createTestPosition,
+  createSupplyEvent,
+  assertMarketState,
+  assertPositionState,
+  assertTransactionCreated,
+  assertRecordCount,
+  expectDecimalEquals,
+} from '../../helpers';
+
+describe('handleSupply', () => {
+  const marketId = '1';
+
+  beforeEach(async () => {
+    await createTestMarket({ id: marketId });
+  });
+
+  describe('happy path', () => {
+    it('increments totalSupplyScaled on market', async () => {
+      const event = createSupplyEvent({
+        scaledAmount: DECIMALS.oneToken,
+      });
+
+      await handleSupply(event, marketId);
+
+      await assertMarketState(marketId, {
+        totalSupplyScaled: DECIMALS.oneToken,
+      });
+    });
+
+    it('creates new position when user has no existing position', async () => {
+      const event = createSupplyEvent({
+        supplier: ADDRESSES.userA,
+        recipient: ADDRESSES.userA,
+        scaledAmount: DECIMALS.oneToken,
+      });
+
+      await handleSupply(event, marketId);
+
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        supplyScaled: DECIMALS.oneToken,
+        debtScaled: '0',
+        collateral: '0',
+      });
+    });
+
+    it('increments existing position supplyScaled', async () => {
+      // Create existing position with 1 token
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        supplyScaled: new Decimal(DECIMALS.oneToken),
+      });
+
+      const event = createSupplyEvent({
+        supplier: ADDRESSES.userA,
+        recipient: ADDRESSES.userA,
+        scaledAmount: DECIMALS.oneToken,
+      });
+
+      await handleSupply(event, marketId);
+
+      // Should have 2 tokens now
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        supplyScaled: '2000000000000000000',
+      });
+    });
+
+    it('creates transaction record with correct action', async () => {
+      const event = createSupplyEvent({
+        supplier: ADDRESSES.userA,
+        recipient: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+        scaledAmount: DECIMALS.oneToken,
+      });
+
+      await handleSupply(event, marketId);
+
+      await assertTransactionCreated(event.txHash, event.logIndex, {
+        action: 'SUPPLY',
+        marketId,
+        userAddress: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+        scaledAmount: DECIMALS.oneToken,
+        recipient: ADDRESSES.userA,
+      });
+    });
+
+    it('records market state snapshot in transaction', async () => {
+      const event = createSupplyEvent({
+        totalSupply: DECIMALS.thousand,
+        totalDebt: DECIMALS.oneToken,
+        utilization: DECIMALS.tenPercent,
+      });
+
+      await handleSupply(event, marketId);
+
+      const tx = await prisma.transaction.findUnique({
+        where: { id: `${event.txHash}:${event.logIndex}` },
+      });
+
+      expectDecimalEquals(tx!.totalSupply, DECIMALS.thousand);
+      expectDecimalEquals(tx!.totalDebt, DECIMALS.oneToken);
+      expectDecimalEquals(tx!.utilization, DECIMALS.tenPercent);
+    });
+
+    it('updates lastInteraction timestamp on existing position', async () => {
+      const oldDate = new Date('2020-01-01');
+      await prisma.userPosition.create({
+        data: {
+          id: `${marketId}:${ADDRESSES.userA}`,
+          marketId,
+          userAddress: ADDRESSES.userA,
+          supplyScaled: new Decimal(DECIMALS.oneToken),
+          debtScaled: new Decimal(0),
+          collateral: new Decimal(0),
+          firstInteraction: oldDate,
+          lastInteraction: oldDate,
+        },
+      });
+
+      const newTimestamp = Math.floor(Date.now() / 1000);
+      const event = createSupplyEvent({
+        supplier: ADDRESSES.userA,
+        recipient: ADDRESSES.userA,
+        timestamp: newTimestamp,
+      });
+
+      await handleSupply(event, marketId);
+
+      const position = await prisma.userPosition.findUnique({
+        where: { id: `${marketId}:${ADDRESSES.userA}` },
+      });
+
+      expect(position!.lastInteraction.getTime()).toBeGreaterThan(oldDate.getTime());
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles supply to different recipient than supplier', async () => {
+      const event = createSupplyEvent({
+        supplier: ADDRESSES.userA,
+        recipient: ADDRESSES.userB,
+        scaledAmount: DECIMALS.oneToken,
+      });
+
+      await handleSupply(event, marketId);
+
+      // Position should be created for recipient, not supplier
+      await assertPositionState(marketId, ADDRESSES.userB, {
+        supplyScaled: DECIMALS.oneToken,
+      });
+      await assertPositionState(marketId, ADDRESSES.userA, { exists: false });
+
+      // Transaction userAddress should be supplier
+      await assertTransactionCreated(event.txHash, event.logIndex, {
+        action: 'SUPPLY',
+        marketId,
+        userAddress: ADDRESSES.userA,
+        recipient: ADDRESSES.userB,
+      });
+    });
+
+    it('handles zero amount supply', async () => {
+      const event = createSupplyEvent({
+        amount: DECIMALS.zero,
+        scaledAmount: DECIMALS.zero,
+      });
+
+      await handleSupply(event, marketId);
+
+      await assertMarketState(marketId, {
+        totalSupplyScaled: '0',
+      });
+
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        supplyScaled: '0',
+      });
+    });
+
+    it('handles large amounts (near Uint128 max)', async () => {
+      const largeAmount = '100000000000000000000000000000'; // 1e29
+
+      const event = createSupplyEvent({
+        amount: largeAmount,
+        scaledAmount: largeAmount,
+      });
+
+      await handleSupply(event, marketId);
+
+      await assertMarketState(marketId, {
+        totalSupplyScaled: largeAmount,
+      });
+    });
+
+    it('throws error when market not found', async () => {
+      const event = createSupplyEvent();
+
+      await expect(handleSupply(event, 'non-existent-market')).rejects.toThrow(
+        'Market not found: non-existent-market'
+      );
+    });
+  });
+
+  describe('atomicity', () => {
+    it('does not create transaction if market update fails', async () => {
+      // Delete the market to cause failure
+      await prisma.market.delete({ where: { id: marketId } });
+
+      const event = createSupplyEvent();
+
+      await expect(handleSupply(event, marketId)).rejects.toThrow();
+
+      // No transaction should be created
+      await assertRecordCount('transaction', 0);
+    });
+  });
+});

--- a/indexer/tests/unit/handlers/update-params.test.ts
+++ b/indexer/tests/unit/handlers/update-params.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Decimal } from 'decimal.js';
+import { handleUpdateParams } from '../../../src/events/handlers';
+import { prisma } from '../../../src/db/client';
+import {
+  ADDRESSES,
+  DECIMALS,
+  createTestMarket,
+  createUpdateParamsEvent,
+  assertMarketSnapshotCreated,
+  assertRecordCount,
+  expectDecimalEquals,
+} from '../../helpers';
+
+describe('handleUpdateParams', () => {
+  const marketId = '1';
+
+  beforeEach(async () => {
+    await createTestMarket({ id: marketId });
+  });
+
+  describe('happy path', () => {
+    it('updates loanToValue (finalLtv)', async () => {
+      const event = createUpdateParamsEvent({
+        finalLtv: '0.75',
+      });
+
+      await handleUpdateParams(event, marketId);
+
+      const market = await prisma.market.findUnique({ where: { id: marketId } });
+      expect(market!.loanToValue.toString()).toBe('0.75');
+    });
+
+    it('updates liquidationThreshold', async () => {
+      const event = createUpdateParamsEvent({
+        finalLiquidationThreshold: '0.9',
+      });
+
+      await handleUpdateParams(event, marketId);
+
+      const market = await prisma.market.findUnique({ where: { id: marketId } });
+      expect(market!.liquidationThreshold.toString()).toBe('0.9');
+    });
+
+    it('updates liquidationBonus', async () => {
+      const event = createUpdateParamsEvent({
+        finalLiquidationBonus: '0.1',
+      });
+
+      await handleUpdateParams(event, marketId);
+
+      const market = await prisma.market.findUnique({ where: { id: marketId } });
+      expect(market!.liquidationBonus.toString()).toBe('0.1');
+    });
+
+    it('updates liquidationProtocolFee', async () => {
+      const event = createUpdateParamsEvent({
+        finalLiquidationProtocolFee: '0.2',
+      });
+
+      await handleUpdateParams(event, marketId);
+
+      const market = await prisma.market.findUnique({ where: { id: marketId } });
+      expect(market!.liquidationProtocolFee.toString()).toBe('0.2');
+    });
+
+    it('updates closeFactor', async () => {
+      const event = createUpdateParamsEvent({
+        finalCloseFactor: '0.6',
+      });
+
+      await handleUpdateParams(event, marketId);
+
+      const market = await prisma.market.findUnique({ where: { id: marketId } });
+      expect(market!.closeFactor.toString()).toBe('0.6');
+    });
+
+    it('updates protocolFee', async () => {
+      const event = createUpdateParamsEvent({
+        finalProtocolFee: '0.15',
+      });
+
+      await handleUpdateParams(event, marketId);
+
+      const market = await prisma.market.findUnique({ where: { id: marketId } });
+      expect(market!.protocolFee.toString()).toBe('0.15');
+    });
+
+    it('updates curatorFee', async () => {
+      const event = createUpdateParamsEvent({
+        finalCuratorFee: '0.1',
+      });
+
+      await handleUpdateParams(event, marketId);
+
+      const market = await prisma.market.findUnique({ where: { id: marketId } });
+      expect(market!.curatorFee.toString()).toBe('0.1');
+    });
+
+    it('updates all 9 parameters at once', async () => {
+      const event = createUpdateParamsEvent({
+        finalLtv: '0.7',
+        finalLiquidationThreshold: '0.8',
+        finalLiquidationBonus: '0.08',
+        finalLiquidationProtocolFee: '0.15',
+        finalCloseFactor: '0.55',
+        finalProtocolFee: '0.12',
+        finalCuratorFee: '0.08',
+        finalSupplyCap: DECIMALS.million,
+        finalBorrowCap: DECIMALS.million,
+        finalEnabled: 'true',
+        finalIsMutable: 'true',
+      });
+
+      await handleUpdateParams(event, marketId);
+
+      const market = await prisma.market.findUnique({ where: { id: marketId } });
+      expectDecimalEquals(market!.loanToValue, '0.7');
+      expectDecimalEquals(market!.liquidationThreshold, '0.8');
+      expectDecimalEquals(market!.liquidationBonus, '0.08');
+      expectDecimalEquals(market!.liquidationProtocolFee, '0.15');
+      expectDecimalEquals(market!.closeFactor, '0.55');
+      expectDecimalEquals(market!.protocolFee, '0.12');
+      expectDecimalEquals(market!.curatorFee, '0.08');
+      expectDecimalEquals(market!.supplyCap, DECIMALS.million);
+      expectDecimalEquals(market!.borrowCap, DECIMALS.million);
+      expect(market!.enabled).toBe(true);
+      expect(market!.isMutable).toBe(true);
+    });
+
+    it('creates MarketSnapshot with updated params', async () => {
+      const timestamp = 1700000000;
+      const event = createUpdateParamsEvent({
+        finalLtv: '0.7',
+        finalLiquidationThreshold: '0.8',
+        finalEnabled: 'true',
+        timestamp,
+      });
+
+      await handleUpdateParams(event, marketId);
+
+      await assertMarketSnapshotCreated(marketId, timestamp, {
+        loanToValue: '0.7',
+        liquidationThreshold: '0.8',
+        enabled: true,
+      });
+    });
+
+    it('does NOT create Transaction record', async () => {
+      const event = createUpdateParamsEvent();
+
+      await handleUpdateParams(event, marketId);
+
+      // No transaction should be created for update_params
+      await assertRecordCount('transaction', 0);
+
+      // But MarketSnapshot should exist
+      await assertRecordCount('marketSnapshot', 1);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles optional supplyCap (sets to null when undefined)', async () => {
+      // First set a supply cap
+      await prisma.market.update({
+        where: { id: marketId },
+        data: { supplyCap: new Decimal(DECIMALS.million) },
+      });
+
+      const event = createUpdateParamsEvent({
+        finalSupplyCap: undefined, // Not provided
+      });
+
+      await handleUpdateParams(event, marketId);
+
+      const market = await prisma.market.findUnique({ where: { id: marketId } });
+      expect(market!.supplyCap).toBeNull();
+    });
+
+    it('handles optional borrowCap (sets to null when undefined)', async () => {
+      // First set a borrow cap
+      await prisma.market.update({
+        where: { id: marketId },
+        data: { borrowCap: new Decimal(DECIMALS.million) },
+      });
+
+      const event = createUpdateParamsEvent({
+        finalBorrowCap: undefined, // Not provided
+      });
+
+      await handleUpdateParams(event, marketId);
+
+      const market = await prisma.market.findUnique({ where: { id: marketId } });
+      expect(market!.borrowCap).toBeNull();
+    });
+
+    it('sets supplyCap and borrowCap when provided', async () => {
+      const event = createUpdateParamsEvent({
+        finalSupplyCap: DECIMALS.million,
+        finalBorrowCap: DECIMALS.thousand,
+      });
+
+      await handleUpdateParams(event, marketId);
+
+      const market = await prisma.market.findUnique({ where: { id: marketId } });
+      expectDecimalEquals(market!.supplyCap, DECIMALS.million);
+      expectDecimalEquals(market!.borrowCap, DECIMALS.thousand);
+    });
+
+    it('converts string "true" to boolean true for enabled', async () => {
+      const event = createUpdateParamsEvent({
+        finalEnabled: 'true',
+      });
+
+      await handleUpdateParams(event, marketId);
+
+      const market = await prisma.market.findUnique({ where: { id: marketId } });
+      expect(market!.enabled).toBe(true);
+    });
+
+    it('converts string "false" to boolean false for enabled', async () => {
+      const event = createUpdateParamsEvent({
+        finalEnabled: 'false',
+      });
+
+      await handleUpdateParams(event, marketId);
+
+      const market = await prisma.market.findUnique({ where: { id: marketId } });
+      expect(market!.enabled).toBe(false);
+    });
+
+    it('converts string "true" to boolean true for isMutable', async () => {
+      const event = createUpdateParamsEvent({
+        finalIsMutable: 'true',
+      });
+
+      await handleUpdateParams(event, marketId);
+
+      const market = await prisma.market.findUnique({ where: { id: marketId } });
+      expect(market!.isMutable).toBe(true);
+    });
+
+    it('converts string "false" to boolean false for isMutable', async () => {
+      const event = createUpdateParamsEvent({
+        finalIsMutable: 'false',
+      });
+
+      await handleUpdateParams(event, marketId);
+
+      const market = await prisma.market.findUnique({ where: { id: marketId } });
+      expect(market!.isMutable).toBe(false);
+    });
+
+    it('snapshot includes calculated totalSupply (scaled * liquidityIndex)', async () => {
+      // Set some scaled supply
+      await prisma.market.update({
+        where: { id: marketId },
+        data: {
+          totalSupplyScaled: new Decimal('1000000000000000000000'), // 1000
+          liquidityIndex: new Decimal('1.1'),
+        },
+      });
+
+      const timestamp = 1700000000;
+      const event = createUpdateParamsEvent({ timestamp });
+
+      await handleUpdateParams(event, marketId);
+
+      const snapshot = await prisma.marketSnapshot.findUnique({
+        where: { id: `${marketId}:${timestamp}` },
+      });
+
+      // totalSupply = 1000 * 1.1 = 1100
+      expectDecimalEquals(snapshot!.totalSupply, '1100000000000000000000');
+    });
+
+    it('snapshot includes calculated totalDebt (scaled * borrowIndex)', async () => {
+      // Set some scaled debt
+      await prisma.market.update({
+        where: { id: marketId },
+        data: {
+          totalDebtScaled: new Decimal('500000000000000000000'), // 500
+          borrowIndex: new Decimal('1.2'),
+        },
+      });
+
+      const timestamp = 1700000000;
+      const event = createUpdateParamsEvent({ timestamp });
+
+      await handleUpdateParams(event, marketId);
+
+      const snapshot = await prisma.marketSnapshot.findUnique({
+        where: { id: `${marketId}:${timestamp}` },
+      });
+
+      // totalDebt = 500 * 1.2 = 600
+      expectDecimalEquals(snapshot!.totalDebt, '600000000000000000000');
+    });
+
+    it('preserves market state fields not in params', async () => {
+      // Set some state
+      await prisma.market.update({
+        where: { id: marketId },
+        data: {
+          totalSupplyScaled: new Decimal(DECIMALS.thousand),
+          totalDebtScaled: new Decimal(DECIMALS.oneToken),
+          totalCollateral: new Decimal(DECIMALS.oneToken),
+          borrowIndex: new Decimal('1.1'),
+          liquidityIndex: new Decimal('1.05'),
+        },
+      });
+
+      const event = createUpdateParamsEvent({
+        finalLtv: '0.9',
+      });
+
+      await handleUpdateParams(event, marketId);
+
+      const market = await prisma.market.findUnique({ where: { id: marketId } });
+      // Param should be updated
+      expectDecimalEquals(market!.loanToValue, '0.9');
+      // State should be preserved
+      expectDecimalEquals(market!.totalSupplyScaled, DECIMALS.thousand);
+      expectDecimalEquals(market!.totalDebtScaled, DECIMALS.oneToken);
+      expectDecimalEquals(market!.totalCollateral, DECIMALS.oneToken);
+      expectDecimalEquals(market!.borrowIndex, '1.1');
+      expectDecimalEquals(market!.liquidityIndex, '1.05');
+    });
+  });
+});

--- a/indexer/tests/unit/handlers/withdraw-collateral.test.ts
+++ b/indexer/tests/unit/handlers/withdraw-collateral.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Decimal } from 'decimal.js';
+import { handleWithdrawCollateral } from '../../../src/events/handlers';
+import { prisma } from '../../../src/db/client';
+import {
+  ADDRESSES,
+  DECIMALS,
+  createTestMarket,
+  createTestPosition,
+  createWithdrawCollateralEvent,
+  assertMarketState,
+  assertPositionState,
+  assertTransactionCreated,
+} from '../../helpers';
+
+describe('handleWithdrawCollateral', () => {
+  const marketId = '1';
+
+  beforeEach(async () => {
+    await createTestMarket({
+      id: marketId,
+      totalCollateral: new Decimal(DECIMALS.thousand),
+    });
+  });
+
+  describe('happy path', () => {
+    it('decrements totalCollateral on market', async () => {
+      const event = createWithdrawCollateralEvent({
+        amount: DECIMALS.oneToken,
+      });
+
+      await handleWithdrawCollateral(event, marketId);
+
+      await assertMarketState(marketId, {
+        totalCollateral: '999000000000000000000',
+      });
+    });
+
+    it('decrements existing position collateral', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        collateral: new Decimal(DECIMALS.thousand),
+      });
+
+      const event = createWithdrawCollateralEvent({
+        withdrawer: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+      });
+
+      await handleWithdrawCollateral(event, marketId);
+
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        collateral: '999000000000000000000',
+      });
+    });
+
+    it('creates transaction with action WITHDRAW_COLLATERAL', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        collateral: new Decimal(DECIMALS.thousand),
+      });
+
+      const event = createWithdrawCollateralEvent({
+        withdrawer: ADDRESSES.userA,
+        recipient: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+      });
+
+      await handleWithdrawCollateral(event, marketId);
+
+      await assertTransactionCreated(event.txHash, event.logIndex, {
+        action: 'WITHDRAW_COLLATERAL',
+        marketId,
+        userAddress: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+        recipient: ADDRESSES.userA,
+      });
+    });
+
+    it('records new totalCollateral in transaction', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        collateral: new Decimal(DECIMALS.thousand),
+      });
+
+      const event = createWithdrawCollateralEvent({
+        withdrawer: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+      });
+
+      await handleWithdrawCollateral(event, marketId);
+
+      const tx = await prisma.transaction.findUnique({
+        where: { id: `${event.txHash}:${event.logIndex}` },
+      });
+
+      expect(tx!.totalCollateral?.toString()).toBe('999000000000000000000');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('does not create position if none exists', async () => {
+      const event = createWithdrawCollateralEvent({
+        withdrawer: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+      });
+
+      await handleWithdrawCollateral(event, marketId);
+
+      // No position should be created
+      await assertPositionState(marketId, ADDRESSES.userA, { exists: false });
+
+      // Market should still be updated
+      await assertMarketState(marketId, {
+        totalCollateral: '999000000000000000000',
+      });
+    });
+
+    it('allows withdrawing to zero collateral', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        collateral: new Decimal(DECIMALS.oneToken),
+      });
+
+      const event = createWithdrawCollateralEvent({
+        withdrawer: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+      });
+
+      await handleWithdrawCollateral(event, marketId);
+
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        collateral: '0',
+      });
+    });
+
+    it('handles withdraw to different recipient', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        collateral: new Decimal(DECIMALS.thousand),
+      });
+
+      const event = createWithdrawCollateralEvent({
+        withdrawer: ADDRESSES.userA,
+        recipient: ADDRESSES.userB,
+        amount: DECIMALS.oneToken,
+      });
+
+      await handleWithdrawCollateral(event, marketId);
+
+      // Withdrawer's position is updated
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        collateral: '999000000000000000000',
+      });
+
+      // No position for recipient
+      await assertPositionState(marketId, ADDRESSES.userB, { exists: false });
+    });
+
+    it('preserves supplyScaled and debtScaled when withdrawing collateral', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        supplyScaled: new Decimal(DECIMALS.thousand),
+        debtScaled: new Decimal(DECIMALS.oneToken),
+        collateral: new Decimal(DECIMALS.thousand),
+      });
+
+      const event = createWithdrawCollateralEvent({
+        withdrawer: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+      });
+
+      await handleWithdrawCollateral(event, marketId);
+
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        supplyScaled: DECIMALS.thousand,
+        debtScaled: DECIMALS.oneToken,
+        collateral: '999000000000000000000',
+      });
+    });
+  });
+});

--- a/indexer/tests/unit/handlers/withdraw.test.ts
+++ b/indexer/tests/unit/handlers/withdraw.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Decimal } from 'decimal.js';
+import { handleWithdraw } from '../../../src/events/handlers';
+import { prisma } from '../../../src/db/client';
+import {
+  ADDRESSES,
+  DECIMALS,
+  createTestMarket,
+  createTestPosition,
+  createWithdrawEvent,
+  assertMarketState,
+  assertPositionState,
+  assertTransactionCreated,
+} from '../../helpers';
+
+describe('handleWithdraw', () => {
+  const marketId = '1';
+
+  beforeEach(async () => {
+    await createTestMarket({
+      id: marketId,
+      totalSupplyScaled: new Decimal(DECIMALS.thousand),
+    });
+  });
+
+  describe('happy path', () => {
+    it('decrements totalSupplyScaled on market', async () => {
+      const event = createWithdrawEvent({
+        scaledDecrease: DECIMALS.oneToken,
+      });
+
+      await handleWithdraw(event, marketId);
+
+      // 1000 - 1 = 999 tokens
+      await assertMarketState(marketId, {
+        totalSupplyScaled: '999000000000000000000',
+      });
+    });
+
+    it('decrements existing position supplyScaled', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        supplyScaled: new Decimal(DECIMALS.thousand),
+      });
+
+      const event = createWithdrawEvent({
+        withdrawer: ADDRESSES.userA,
+        scaledDecrease: DECIMALS.oneToken,
+      });
+
+      await handleWithdraw(event, marketId);
+
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        supplyScaled: '999000000000000000000',
+      });
+    });
+
+    it('creates transaction record with action WITHDRAW', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        supplyScaled: new Decimal(DECIMALS.thousand),
+      });
+
+      const event = createWithdrawEvent({
+        withdrawer: ADDRESSES.userA,
+        recipient: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+        scaledDecrease: DECIMALS.oneToken,
+      });
+
+      await handleWithdraw(event, marketId);
+
+      await assertTransactionCreated(event.txHash, event.logIndex, {
+        action: 'WITHDRAW',
+        marketId,
+        userAddress: ADDRESSES.userA,
+        amount: DECIMALS.oneToken,
+        scaledAmount: DECIMALS.oneToken,
+        recipient: ADDRESSES.userA,
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('does not create position if none exists', async () => {
+      const event = createWithdrawEvent({
+        withdrawer: ADDRESSES.userA,
+        scaledDecrease: DECIMALS.oneToken,
+      });
+
+      await handleWithdraw(event, marketId);
+
+      // Position should not be created
+      await assertPositionState(marketId, ADDRESSES.userA, { exists: false });
+
+      // But market should still be updated
+      await assertMarketState(marketId, {
+        totalSupplyScaled: '999000000000000000000',
+      });
+    });
+
+    it('allows withdrawing to zero balance', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        supplyScaled: new Decimal(DECIMALS.oneToken),
+      });
+
+      const event = createWithdrawEvent({
+        withdrawer: ADDRESSES.userA,
+        scaledDecrease: DECIMALS.oneToken,
+      });
+
+      await handleWithdraw(event, marketId);
+
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        supplyScaled: '0',
+      });
+    });
+
+    it('handles withdraw to different recipient', async () => {
+      await createTestPosition(marketId, ADDRESSES.userA, {
+        supplyScaled: new Decimal(DECIMALS.thousand),
+      });
+
+      const event = createWithdrawEvent({
+        withdrawer: ADDRESSES.userA,
+        recipient: ADDRESSES.userB,
+        scaledDecrease: DECIMALS.oneToken,
+      });
+
+      await handleWithdraw(event, marketId);
+
+      // Position for withdrawer is updated
+      await assertPositionState(marketId, ADDRESSES.userA, {
+        supplyScaled: '999000000000000000000',
+      });
+
+      // No position created for recipient
+      await assertPositionState(marketId, ADDRESSES.userB, { exists: false });
+    });
+
+    it('throws error when market not found', async () => {
+      const event = createWithdrawEvent();
+
+      await expect(handleWithdraw(event, 'non-existent')).rejects.toThrow(
+        'Market not found: non-existent'
+      );
+    });
+
+    it('updates lastInteraction timestamp', async () => {
+      const oldDate = new Date('2020-01-01');
+      await prisma.userPosition.create({
+        data: {
+          id: `${marketId}:${ADDRESSES.userA}`,
+          marketId,
+          userAddress: ADDRESSES.userA,
+          supplyScaled: new Decimal(DECIMALS.thousand),
+          debtScaled: new Decimal(0),
+          collateral: new Decimal(0),
+          firstInteraction: oldDate,
+          lastInteraction: oldDate,
+        },
+      });
+
+      const event = createWithdrawEvent({
+        withdrawer: ADDRESSES.userA,
+        timestamp: Math.floor(Date.now() / 1000),
+      });
+
+      await handleWithdraw(event, marketId);
+
+      const position = await prisma.userPosition.findUnique({
+        where: { id: `${marketId}:${ADDRESSES.userA}` },
+      });
+
+      expect(position!.lastInteraction.getTime()).toBeGreaterThan(oldDate.getTime());
+    });
+  });
+});

--- a/indexer/tests/unit/parser.test.ts
+++ b/indexer/tests/unit/parser.test.ts
@@ -1,0 +1,475 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseEventAttributes,
+  parseMarketCreatedEvent,
+  parseMarketEvent,
+} from '../../src/events/parser';
+import type { Event as TendermintEvent } from '@cosmjs/tendermint-rpc/build/tendermint37/responses';
+import { ADDRESSES, DECIMALS } from '../helpers';
+
+describe('Event Parsers', () => {
+  describe('parseEventAttributes', () => {
+    it('converts Tendermint event attributes to Record<string, string>', () => {
+      const event: TendermintEvent = {
+        type: 'wasm',
+        attributes: [
+          { key: 'action', value: 'supply' },
+          { key: 'amount', value: '1000' },
+          { key: '_contract_address', value: ADDRESSES.market1 },
+        ],
+      };
+
+      const result = parseEventAttributes(event);
+
+      expect(result).toEqual({
+        action: 'supply',
+        amount: '1000',
+        _contract_address: ADDRESSES.market1,
+      });
+    });
+
+    it('handles empty attributes', () => {
+      const event: TendermintEvent = {
+        type: 'wasm',
+        attributes: [],
+      };
+
+      const result = parseEventAttributes(event);
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('parseMarketCreatedEvent', () => {
+    const baseMetadata = {
+      txHash: 'ABC123',
+      blockHeight: 12345,
+      timestamp: 1700000000,
+      logIndex: 0,
+    };
+
+    it('parses valid market_instantiated event', () => {
+      const attributes = {
+        action: 'market_instantiated',
+        market_id: '1',
+        market_address: ADDRESSES.market1,
+      };
+
+      const result = parseMarketCreatedEvent(
+        attributes,
+        baseMetadata.txHash,
+        baseMetadata.blockHeight,
+        baseMetadata.timestamp,
+        baseMetadata.logIndex
+      );
+
+      expect(result).toEqual({
+        action: 'market_instantiated',
+        marketId: '1',
+        marketAddress: ADDRESSES.market1,
+        txHash: 'ABC123',
+        blockHeight: 12345,
+        timestamp: 1700000000,
+        logIndex: 0,
+      });
+    });
+
+    it('returns null for wrong action', () => {
+      const attributes = {
+        action: 'supply',
+        market_id: '1',
+        market_address: ADDRESSES.market1,
+      };
+
+      const result = parseMarketCreatedEvent(
+        attributes,
+        baseMetadata.txHash,
+        baseMetadata.blockHeight,
+        baseMetadata.timestamp,
+        baseMetadata.logIndex
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when market_id is missing', () => {
+      const attributes = {
+        action: 'market_instantiated',
+        market_address: ADDRESSES.market1,
+      };
+
+      const result = parseMarketCreatedEvent(
+        attributes,
+        baseMetadata.txHash,
+        baseMetadata.blockHeight,
+        baseMetadata.timestamp,
+        baseMetadata.logIndex
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when market_address is missing', () => {
+      const attributes = {
+        action: 'market_instantiated',
+        market_id: '1',
+      };
+
+      const result = parseMarketCreatedEvent(
+        attributes,
+        baseMetadata.txHash,
+        baseMetadata.blockHeight,
+        baseMetadata.timestamp,
+        baseMetadata.logIndex
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('parseMarketEvent', () => {
+    const baseMetadata = {
+      marketAddress: ADDRESSES.market1,
+      txHash: 'ABC123',
+      blockHeight: 12345,
+      timestamp: 1700000000,
+      logIndex: 0,
+    };
+
+    describe('supply', () => {
+      it('parses supply event with all fields', () => {
+        const attributes = {
+          action: 'supply',
+          supplier: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: DECIMALS.oneToken,
+          scaled_amount: DECIMALS.oneToken,
+          total_supply: DECIMALS.thousand,
+          total_debt: DECIMALS.zero,
+          utilization: DECIMALS.zero,
+        };
+
+        const result = parseMarketEvent(
+          attributes,
+          baseMetadata.marketAddress,
+          baseMetadata.txHash,
+          baseMetadata.blockHeight,
+          baseMetadata.timestamp,
+          baseMetadata.logIndex
+        );
+
+        expect(result).toEqual({
+          action: 'supply',
+          supplier: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: DECIMALS.oneToken,
+          scaledAmount: DECIMALS.oneToken,
+          totalSupply: DECIMALS.thousand,
+          totalDebt: DECIMALS.zero,
+          utilization: DECIMALS.zero,
+          marketAddress: ADDRESSES.market1,
+          txHash: 'ABC123',
+          blockHeight: 12345,
+          timestamp: 1700000000,
+          logIndex: 0,
+        });
+      });
+    });
+
+    describe('withdraw', () => {
+      it('parses withdraw event with scaled_decrease', () => {
+        const attributes = {
+          action: 'withdraw',
+          withdrawer: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: DECIMALS.oneToken,
+          scaled_decrease: DECIMALS.oneToken,
+          total_supply: DECIMALS.zero,
+          total_debt: DECIMALS.zero,
+          utilization: DECIMALS.zero,
+        };
+
+        const result = parseMarketEvent(
+          attributes,
+          baseMetadata.marketAddress,
+          baseMetadata.txHash,
+          baseMetadata.blockHeight,
+          baseMetadata.timestamp,
+          baseMetadata.logIndex
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.action).toBe('withdraw');
+        expect((result as any).withdrawer).toBe(ADDRESSES.userA);
+        expect((result as any).scaledDecrease).toBe(DECIMALS.oneToken);
+      });
+    });
+
+    describe('supply_collateral', () => {
+      it('parses supply_collateral event (no scaled amount)', () => {
+        const attributes = {
+          action: 'supply_collateral',
+          supplier: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: DECIMALS.oneToken,
+        };
+
+        const result = parseMarketEvent(
+          attributes,
+          baseMetadata.marketAddress,
+          baseMetadata.txHash,
+          baseMetadata.blockHeight,
+          baseMetadata.timestamp,
+          baseMetadata.logIndex
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.action).toBe('supply_collateral');
+        expect((result as any).supplier).toBe(ADDRESSES.userA);
+        expect((result as any).amount).toBe(DECIMALS.oneToken);
+        // Should not have scaledAmount field
+        expect((result as any).scaledAmount).toBeUndefined();
+      });
+    });
+
+    describe('withdraw_collateral', () => {
+      it('parses withdraw_collateral event', () => {
+        const attributes = {
+          action: 'withdraw_collateral',
+          withdrawer: ADDRESSES.userA,
+          recipient: ADDRESSES.userB,
+          amount: DECIMALS.oneToken,
+        };
+
+        const result = parseMarketEvent(
+          attributes,
+          baseMetadata.marketAddress,
+          baseMetadata.txHash,
+          baseMetadata.blockHeight,
+          baseMetadata.timestamp,
+          baseMetadata.logIndex
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.action).toBe('withdraw_collateral');
+        expect((result as any).withdrawer).toBe(ADDRESSES.userA);
+        expect((result as any).recipient).toBe(ADDRESSES.userB);
+      });
+    });
+
+    describe('borrow', () => {
+      it('parses borrow event with scaled_amount', () => {
+        const attributes = {
+          action: 'borrow',
+          borrower: ADDRESSES.userA,
+          recipient: ADDRESSES.userA,
+          amount: DECIMALS.oneToken,
+          scaled_amount: DECIMALS.oneToken,
+          total_supply: DECIMALS.thousand,
+          total_debt: DECIMALS.oneToken,
+          utilization: DECIMALS.tenPercent,
+        };
+
+        const result = parseMarketEvent(
+          attributes,
+          baseMetadata.marketAddress,
+          baseMetadata.txHash,
+          baseMetadata.blockHeight,
+          baseMetadata.timestamp,
+          baseMetadata.logIndex
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.action).toBe('borrow');
+        expect((result as any).borrower).toBe(ADDRESSES.userA);
+        expect((result as any).scaledAmount).toBe(DECIMALS.oneToken);
+      });
+    });
+
+    describe('repay', () => {
+      it('parses repay event with repayer and borrower', () => {
+        const attributes = {
+          action: 'repay',
+          repayer: ADDRESSES.userB,
+          borrower: ADDRESSES.userA,
+          amount: DECIMALS.oneToken,
+          scaled_decrease: DECIMALS.oneToken,
+          total_supply: DECIMALS.thousand,
+          total_debt: DECIMALS.zero,
+          utilization: DECIMALS.zero,
+        };
+
+        const result = parseMarketEvent(
+          attributes,
+          baseMetadata.marketAddress,
+          baseMetadata.txHash,
+          baseMetadata.blockHeight,
+          baseMetadata.timestamp,
+          baseMetadata.logIndex
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.action).toBe('repay');
+        expect((result as any).repayer).toBe(ADDRESSES.userB);
+        expect((result as any).borrower).toBe(ADDRESSES.userA);
+        expect((result as any).scaledDecrease).toBe(DECIMALS.oneToken);
+      });
+    });
+
+    describe('liquidate', () => {
+      it('parses liquidate event with all liquidation fields', () => {
+        const attributes = {
+          action: 'liquidate',
+          liquidator: ADDRESSES.liquidator,
+          borrower: ADDRESSES.userA,
+          debt_repaid: DECIMALS.oneToken,
+          collateral_seized: DECIMALS.oneToken,
+          protocol_fee: DECIMALS.dust,
+          scaled_debt_decrease: DECIMALS.oneToken,
+          total_supply: DECIMALS.thousand,
+          total_debt: DECIMALS.zero,
+          total_collateral: DECIMALS.zero,
+          utilization: DECIMALS.zero,
+        };
+
+        const result = parseMarketEvent(
+          attributes,
+          baseMetadata.marketAddress,
+          baseMetadata.txHash,
+          baseMetadata.blockHeight,
+          baseMetadata.timestamp,
+          baseMetadata.logIndex
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.action).toBe('liquidate');
+        expect((result as any).liquidator).toBe(ADDRESSES.liquidator);
+        expect((result as any).borrower).toBe(ADDRESSES.userA);
+        expect((result as any).debtRepaid).toBe(DECIMALS.oneToken);
+        expect((result as any).collateralSeized).toBe(DECIMALS.oneToken);
+        expect((result as any).protocolFee).toBe(DECIMALS.dust);
+        expect((result as any).scaledDebtDecrease).toBe(DECIMALS.oneToken);
+        expect((result as any).totalCollateral).toBe(DECIMALS.zero);
+      });
+    });
+
+    describe('accrue_interest', () => {
+      it('parses accrue_interest event with indices and rates', () => {
+        const attributes = {
+          action: 'accrue_interest',
+          borrow_index: '1.05',
+          liquidity_index: '1.03',
+          borrow_rate: '0.05',
+          liquidity_rate: '0.03',
+          last_update: '1700000000',
+        };
+
+        const result = parseMarketEvent(
+          attributes,
+          baseMetadata.marketAddress,
+          baseMetadata.txHash,
+          baseMetadata.blockHeight,
+          baseMetadata.timestamp,
+          baseMetadata.logIndex
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.action).toBe('accrue_interest');
+        expect((result as any).borrowIndex).toBe('1.05');
+        expect((result as any).liquidityIndex).toBe('1.03');
+        expect((result as any).borrowRate).toBe('0.05');
+        expect((result as any).liquidityRate).toBe('0.03');
+        expect((result as any).lastUpdate).toBe('1700000000');
+      });
+    });
+
+    describe('update_params', () => {
+      it('parses update_params event with all parameter fields', () => {
+        const attributes = {
+          action: 'update_params',
+          final_ltv: '0.8',
+          final_liquidation_threshold: '0.85',
+          final_liquidation_bonus: '0.05',
+          final_liquidation_protocol_fee: '0.1',
+          final_close_factor: '0.5',
+          final_protocol_fee: '0.1',
+          final_curator_fee: '0.05',
+          final_supply_cap: DECIMALS.million,
+          final_borrow_cap: DECIMALS.million,
+          final_enabled: 'true',
+          final_is_mutable: 'false',
+        };
+
+        const result = parseMarketEvent(
+          attributes,
+          baseMetadata.marketAddress,
+          baseMetadata.txHash,
+          baseMetadata.blockHeight,
+          baseMetadata.timestamp,
+          baseMetadata.logIndex
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.action).toBe('update_params');
+        expect((result as any).finalLtv).toBe('0.8');
+        expect((result as any).finalLiquidationThreshold).toBe('0.85');
+        expect((result as any).finalLiquidationBonus).toBe('0.05');
+        expect((result as any).finalLiquidationProtocolFee).toBe('0.1');
+        expect((result as any).finalCloseFactor).toBe('0.5');
+        expect((result as any).finalProtocolFee).toBe('0.1');
+        expect((result as any).finalCuratorFee).toBe('0.05');
+        expect((result as any).finalSupplyCap).toBe(DECIMALS.million);
+        expect((result as any).finalBorrowCap).toBe(DECIMALS.million);
+        expect((result as any).finalEnabled).toBe('true');
+        expect((result as any).finalIsMutable).toBe('false');
+      });
+
+      it('handles optional supply_cap and borrow_cap (undefined)', () => {
+        const attributes = {
+          action: 'update_params',
+          final_ltv: '0.8',
+          final_liquidation_threshold: '0.85',
+          final_liquidation_bonus: '0.05',
+          final_liquidation_protocol_fee: '0.1',
+          final_close_factor: '0.5',
+          final_protocol_fee: '0.1',
+          final_curator_fee: '0.05',
+          final_enabled: 'true',
+          final_is_mutable: 'true',
+        };
+
+        const result = parseMarketEvent(
+          attributes,
+          baseMetadata.marketAddress,
+          baseMetadata.txHash,
+          baseMetadata.blockHeight,
+          baseMetadata.timestamp,
+          baseMetadata.logIndex
+        );
+
+        expect(result).not.toBeNull();
+        expect((result as any).finalSupplyCap).toBeUndefined();
+        expect((result as any).finalBorrowCap).toBeUndefined();
+      });
+    });
+
+    describe('unknown action', () => {
+      it('returns null for unknown action type', () => {
+        const attributes = {
+          action: 'unknown_action',
+          some_field: 'value',
+        };
+
+        const result = parseMarketEvent(
+          attributes,
+          baseMetadata.marketAddress,
+          baseMetadata.txHash,
+          baseMetadata.blockHeight,
+          baseMetadata.timestamp,
+          baseMetadata.logIndex
+        );
+
+        expect(result).toBeNull();
+      });
+    });
+  });
+});

--- a/indexer/vitest.config.ts
+++ b/indexer/vitest.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    setupFiles: ['./tests/setup.ts'],
+    include: ['tests/**/*.test.ts'],
+    env: {
+      DATABASE_URL: process.env.DATABASE_URL || 'postgresql://josiahkendall@localhost:5432/stone_test',
+      RPC_ENDPOINT: 'http://localhost:26657',
+      CHAIN_ID: 'testing',
+      FACTORY_ADDRESS: 'cosmos1factoryqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq',
+      MARKET_CODE_ID: '1',
+      LOG_LEVEL: 'error',
+    },
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: [
+        'src/index.ts',
+        'src/api/**',
+        'src/utils/logger.ts',
+        'src/config/index.ts',
+      ],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 75,
+        statements: 80,
+      },
+    },
+    testTimeout: 30000,
+    hookTimeout: 30000,
+    fileParallelism: false, // Run test files sequentially for DB isolation
+    sequence: {
+      shuffle: false,
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Add complete test suite for the Stone Finance indexer with 179 tests across 17 test files
- Implement unit tests for all 10 event handlers and the event parser
- Add integration tests for block processor and chain reorganization handling
- Create end-to-end scenario tests for lending flows, liquidation flows, and multi-user/multi-market interactions

## Test Coverage
- **handlers.ts**: 97.94% statement coverage
- **parser.ts**: 89.57% statement coverage
- **block-processor.ts**: 85.76% statement coverage

## Test Structure
```
tests/
├── setup.ts                    # Test database setup and mocking
├── helpers/
│   ├── fixtures.ts             # Test data factories
│   ├── mocks.ts                # Tendermint/CosmWasm client mocks
│   ├── events.ts               # Event fixture factories
│   └── assertions.ts           # Custom assertion helpers
├── unit/
│   ├── parser.test.ts          # Event parsing tests (17 tests)
│   └── handlers/               # Handler tests (103 tests)
│       ├── supply.test.ts
│       ├── withdraw.test.ts
│       ├── borrow.test.ts
│       ├── repay.test.ts
│       ├── supply-collateral.test.ts
│       ├── withdraw-collateral.test.ts
│       ├── liquidate.test.ts
│       ├── accrue-interest.test.ts
│       ├── update-params.test.ts
│       └── market-created.test.ts
├── integration/
│   ├── block-processor.test.ts # Block processing tests (12 tests)
│   └── reorg-handling.test.ts  # Chain reorg tests (13 tests)
└── scenarios/
    ├── lending-flow.test.ts    # Supply→Borrow→Repay→Withdraw (6 tests)
    ├── liquidation-flow.test.ts # Liquidation scenarios (6 tests)
    ├── multi-user.test.ts      # Multiple users (7 tests)
    └── multi-market.test.ts    # Multiple markets (7 tests)
```

## Test Commands
- `npm test` - Run all tests
- `npm run test:watch` - Run tests in watch mode
- `npm run test:coverage` - Run tests with coverage report
- `npm run test:unit` - Run unit tests only
- `npm run test:integration` - Run integration tests only
- `npm run test:scenarios` - Run scenario tests only

## Test plan
- [x] All 179 tests passing
- [x] Coverage thresholds met (>80% on key files)
- [x] Tests run in isolation with database cleanup between tests
- [x] Run tests in CI environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)