### PR TITLE
Add continuous market snapshot collection with pruning

### DIFF
--- a/indexer/src/events/handlers.ts
+++ b/indexer/src/events/handlers.ts
@@ -35,46 +35,69 @@ export async function handleMarketCreated(event: PartialMarketCreatedEvent): Pro
     const { config, params } = await queryMarketInfo(event.marketAddress);
     logger.info('Market info fetched', { marketAddress: event.marketAddress });
 
-    await prisma.market.create({
-      data: {
-        id: event.marketId,
-        marketAddress: event.marketAddress,
-        curator: config.curator,
-        collateralDenom: config.collateral_denom,
-        debtDenom: config.debt_denom,
-        oracle: config.oracle,
-        createdAt: new Date(event.timestamp * 1000),
-        createdAtBlock: BigInt(event.blockHeight),
+    await prisma.$transaction(async (tx) => {
+      await tx.market.create({
+        data: {
+          id: event.marketId,
+          marketAddress: event.marketAddress,
+          curator: config.curator,
+          collateralDenom: config.collateral_denom,
+          debtDenom: config.debt_denom,
+          oracle: config.oracle,
+          createdAt: new Date(event.timestamp * 1000),
+          createdAtBlock: BigInt(event.blockHeight),
 
-        // Use params from contract params query
-        loanToValue: new Decimal(params.loan_to_value),
-        liquidationThreshold: new Decimal(params.liquidation_threshold),
-        liquidationBonus: new Decimal(params.liquidation_bonus),
-        liquidationProtocolFee: new Decimal(params.liquidation_protocol_fee),
-        closeFactor: new Decimal(params.close_factor),
-        interestRateModel: params.interest_rate_model as object,
-        protocolFee: new Decimal(params.protocol_fee),
-        curatorFee: new Decimal(params.curator_fee),
-        supplyCap: params.supply_cap ? new Decimal(params.supply_cap) : null,
-        borrowCap: params.borrow_cap ? new Decimal(params.borrow_cap) : null,
-        enabled: params.enabled,
-        isMutable: params.is_mutable,
+          // Use params from contract params query
+          loanToValue: new Decimal(params.loan_to_value),
+          liquidationThreshold: new Decimal(params.liquidation_threshold),
+          liquidationBonus: new Decimal(params.liquidation_bonus),
+          liquidationProtocolFee: new Decimal(params.liquidation_protocol_fee),
+          closeFactor: new Decimal(params.close_factor),
+          interestRateModel: params.interest_rate_model as object,
+          protocolFee: new Decimal(params.protocol_fee),
+          curatorFee: new Decimal(params.curator_fee),
+          supplyCap: params.supply_cap ? new Decimal(params.supply_cap) : null,
+          borrowCap: params.borrow_cap ? new Decimal(params.borrow_cap) : null,
+          enabled: params.enabled,
+          isMutable: params.is_mutable,
 
-        // Initialize state
-        borrowIndex: new Decimal(1),
-        liquidityIndex: new Decimal(1),
-        borrowRate: new Decimal(0),
-        liquidityRate: new Decimal(0),
-        totalSupplyScaled: new Decimal(0),
-        totalDebtScaled: new Decimal(0),
-        totalCollateral: new Decimal(0),
-        lastUpdate: BigInt(event.timestamp),
-        utilization: new Decimal(0),
-        availableLiquidity: new Decimal(0),
-      },
+          // Initialize state
+          borrowIndex: new Decimal(1),
+          liquidityIndex: new Decimal(1),
+          borrowRate: new Decimal(0),
+          liquidityRate: new Decimal(0),
+          totalSupplyScaled: new Decimal(0),
+          totalDebtScaled: new Decimal(0),
+          totalCollateral: new Decimal(0),
+          lastUpdate: BigInt(event.timestamp),
+          utilization: new Decimal(0),
+          availableLiquidity: new Decimal(0),
+        },
+      });
+
+      // Create initial snapshot for the market
+      await tx.marketSnapshot.create({
+        data: {
+          id: `${event.marketId}:${event.timestamp}`,
+          marketId: event.marketId,
+          timestamp: new Date(event.timestamp * 1000),
+          blockHeight: BigInt(event.blockHeight),
+          borrowIndex: new Decimal(1),
+          liquidityIndex: new Decimal(1),
+          borrowRate: new Decimal(0),
+          liquidityRate: new Decimal(0),
+          totalSupply: new Decimal(0),
+          totalDebt: new Decimal(0),
+          totalCollateral: new Decimal(0),
+          utilization: new Decimal(0),
+          loanToValue: new Decimal(params.loan_to_value),
+          liquidationThreshold: new Decimal(params.liquidation_threshold),
+          enabled: params.enabled,
+        },
+      });
     });
 
-    logger.info('Market created in database', {
+    logger.info('Market created in database with initial snapshot', {
       marketId: event.marketId,
       collateralDenom: config.collateral_denom,
       debtDenom: config.debt_denom,
@@ -614,7 +637,7 @@ export async function handleAccrueInterest(
   try {
     await prisma.$transaction(async (tx) => {
       // Update market state
-      await tx.market.update({
+      const market = await tx.market.update({
         where: { id: marketId },
         data: {
           borrowIndex: new Decimal(event.borrowIndex),
@@ -637,6 +660,32 @@ export async function handleAccrueInterest(
           liquidityIndex: new Decimal(event.liquidityIndex),
           borrowRate: new Decimal(event.borrowRate),
           liquidityRate: new Decimal(event.liquidityRate),
+        },
+      });
+
+      // Create market snapshot for historical tracking
+      const borrowIndex = new Decimal(event.borrowIndex);
+      const liquidityIndex = new Decimal(event.liquidityIndex);
+      const totalSupply = new Decimal(market.totalSupplyScaled.toString()).mul(liquidityIndex);
+      const totalDebt = new Decimal(market.totalDebtScaled.toString()).mul(borrowIndex);
+
+      await tx.marketSnapshot.create({
+        data: {
+          id: `${marketId}:${event.timestamp}`,
+          marketId,
+          timestamp: new Date(event.timestamp * 1000),
+          blockHeight: BigInt(event.blockHeight),
+          borrowIndex,
+          liquidityIndex,
+          borrowRate: new Decimal(event.borrowRate),
+          liquidityRate: new Decimal(event.liquidityRate),
+          totalSupply,
+          totalDebt,
+          totalCollateral: market.totalCollateral,
+          utilization: market.utilization || new Decimal(0),
+          loanToValue: market.loanToValue,
+          liquidationThreshold: market.liquidationThreshold,
+          enabled: market.enabled,
         },
       });
     });

--- a/indexer/src/index.ts
+++ b/indexer/src/index.ts
@@ -10,6 +10,7 @@ import {
   handleReorg,
 } from './indexer/block-processor';
 import { startGraphQLServer } from './api/server';
+import { pruneSnapshots, shouldPruneSnapshots } from './indexer/snapshot-pruning';
 
 let shouldStop = false;
 let graphQLShutdown: (() => Promise<void>) | null = null;
@@ -94,6 +95,11 @@ async function runIndexer(): Promise<void> {
               lagPercentage: ((lag / currentHeight) * 100).toFixed(2) + '%',
             });
           }
+        }
+
+        // Prune old snapshots periodically to manage database size
+        if (shouldPruneSnapshots(lastProcessed)) {
+          await pruneSnapshots();
         }
 
         // Small delay between batches to avoid overwhelming the RPC

--- a/indexer/src/indexer/snapshot-pruning.ts
+++ b/indexer/src/indexer/snapshot-pruning.ts
@@ -1,0 +1,162 @@
+import { prisma } from '../db/client';
+import { logger } from '../utils/logger';
+
+/**
+ * Snapshot pruning strategy:
+ * - Last 24 hours: Keep all snapshots (full resolution)
+ * - 1-7 days ago: Keep one snapshot per hour
+ * - 7-30 days ago: Keep one snapshot per 6 hours
+ * - 30+ days ago: Keep one snapshot per day
+ */
+
+/**
+ * Prune old market snapshots to manage database size
+ * Should be called periodically (e.g., every 1000 blocks or once per hour)
+ */
+export async function pruneSnapshots(): Promise<void> {
+  const startTime = Date.now();
+  logger.info('Starting snapshot pruning');
+
+  try {
+    const now = new Date();
+
+    // Get all markets
+    const markets = await prisma.market.findMany({
+      select: { id: true },
+    });
+
+    let totalDeleted = 0;
+
+    for (const market of markets) {
+      const deleted = await pruneMarketSnapshots(market.id, now);
+      totalDeleted += deleted;
+    }
+
+    const duration = Date.now() - startTime;
+    logger.info('Snapshot pruning complete', {
+      marketsProcessed: markets.length,
+      snapshotsDeleted: totalDeleted,
+      durationMs: duration,
+    });
+  } catch (error) {
+    logger.error('Error during snapshot pruning', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * Prune snapshots for a single market
+ */
+async function pruneMarketSnapshots(marketId: string, now: Date): Promise<number> {
+  let totalDeleted = 0;
+
+  // Calculate time boundaries
+  const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+  // Prune 1-7 day old snapshots to hourly
+  totalDeleted += await pruneToInterval(marketId, sevenDaysAgo, oneDayAgo, 60 * 60 * 1000); // 1 hour
+
+  // Prune 7-30 day old snapshots to 6-hourly
+  totalDeleted += await pruneToInterval(marketId, thirtyDaysAgo, sevenDaysAgo, 6 * 60 * 60 * 1000); // 6 hours
+
+  // Prune 30+ day old snapshots to daily
+  totalDeleted += await pruneToInterval(marketId, new Date(0), thirtyDaysAgo, 24 * 60 * 60 * 1000); // 24 hours
+
+  return totalDeleted;
+}
+
+/**
+ * Prune snapshots within a time range to keep only one per interval
+ */
+async function pruneToInterval(
+  marketId: string,
+  startTime: Date,
+  endTime: Date,
+  intervalMs: number
+): Promise<number> {
+  // Get all snapshots in the time range
+  const snapshots = await prisma.marketSnapshot.findMany({
+    where: {
+      marketId,
+      timestamp: {
+        gte: startTime,
+        lt: endTime,
+      },
+    },
+    orderBy: { timestamp: 'asc' },
+    select: { id: true, timestamp: true },
+  });
+
+  if (snapshots.length <= 1) {
+    return 0;
+  }
+
+  // Group snapshots by interval bucket
+  const buckets = new Map<number, { id: string; timestamp: Date }[]>();
+
+  for (const snapshot of snapshots) {
+    const bucketKey = Math.floor(snapshot.timestamp.getTime() / intervalMs);
+    if (!buckets.has(bucketKey)) {
+      buckets.set(bucketKey, []);
+    }
+    buckets.get(bucketKey)!.push(snapshot);
+  }
+
+  // Collect IDs to delete (keep the last snapshot in each bucket)
+  const idsToDelete: string[] = [];
+
+  for (const bucket of buckets.values()) {
+    if (bucket.length > 1) {
+      // Sort by timestamp and keep the last one (most recent in bucket)
+      bucket.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+      // Delete all but the last one
+      for (let i = 0; i < bucket.length - 1; i++) {
+        idsToDelete.push(bucket[i].id);
+      }
+    }
+  }
+
+  if (idsToDelete.length === 0) {
+    return 0;
+  }
+
+  // Delete in batches to avoid overwhelming the database
+  const batchSize = 100;
+  let deleted = 0;
+
+  for (let i = 0; i < idsToDelete.length; i += batchSize) {
+    const batch = idsToDelete.slice(i, i + batchSize);
+    const result = await prisma.marketSnapshot.deleteMany({
+      where: { id: { in: batch } },
+    });
+    deleted += result.count;
+  }
+
+  return deleted;
+}
+
+/**
+ * Track when pruning was last run
+ */
+let lastPruningBlock = 0;
+const PRUNING_INTERVAL_BLOCKS = 1000;
+
+/**
+ * Check if pruning should run based on current block height
+ */
+export function shouldPruneSnapshots(currentBlock: number): boolean {
+  if (lastPruningBlock === 0) {
+    lastPruningBlock = currentBlock;
+    return false; // Don't prune on first run
+  }
+
+  if (currentBlock - lastPruningBlock >= PRUNING_INTERVAL_BLOCKS) {
+    lastPruningBlock = currentBlock;
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary
- Create initial snapshot when markets are instantiated to ensure baseline historical data
- Create snapshots on every AccrueInterest event for continuous tracking of market state
- Add periodic pruning to manage database size over time

## Pruning Strategy
- Last 24 hours: Keep all snapshots (full resolution)
- 1-7 days ago: Keep one snapshot per hour
- 7-30 days ago: Keep one snapshot per 6 hours  
- 30+ days ago: Keep one snapshot per day

## Test plan
- [ ] Verify initial snapshot is created when a new market is instantiated
- [ ] Verify snapshots are created on AccrueInterest events
- [ ] Verify pruning runs periodically and consolidates old snapshots correctly
- [ ] Verify frontend charts display historical data

🤖 Generated with [Claude Code](https://claude.com/claude-code)