### PR TITLE
Add staging environment to GitHub deployments sidebar

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -11,6 +11,7 @@ concurrency:
 
 permissions:
   contents: read
+  deployments: write
 
 env:
   HETZNER_LOCATION: nbg1
@@ -58,6 +59,9 @@ jobs:
   deploy:
     needs: build-contracts
     runs-on: ubuntu-latest
+    environment:
+      name: staging
+      url: http://${{ steps.get-ip.outputs.ip }}:3000
     outputs:
       server_ip: ${{ steps.get-ip.outputs.ip }}
     steps:


### PR DESCRIPTION
## Summary
- Configure staging workflow to use GitHub's environment feature
- Adds `deployments: write` permission to allow creating deployment records
- Staging deployments will now appear in the repository sidebar with direct links to the frontend

## Test plan
- [ ] Merge and trigger a staging deployment (push to master or manual dispatch)
- [ ] Verify "staging" environment appears in the repository's Environments sidebar
- [ ] Confirm the environment URL links to the correct staging frontend