### PR TITLE
Fix repay event parser to use correct 'payer' attribute

### DIFF
--- a/indexer/src/events/parser.ts
+++ b/indexer/src/events/parser.ts
@@ -159,7 +159,7 @@ export function parseMarketEvent(
     case 'repay':
       return {
         action: 'repay',
-        repayer: attributes.repayer,
+        repayer: attributes.payer,
         borrower: attributes.borrower,
         amount: attributes.amount,
         scaledDecrease: attributes.scaled_decrease,

--- a/indexer/tests/helpers/events.ts
+++ b/indexer/tests/helpers/events.ts
@@ -227,7 +227,7 @@ export function eventToRawAttributes(
     attrs.recipient = event.recipient;
   }
   if ('borrower' in event && 'repayer' in event) {
-    attrs.repayer = event.repayer;
+    attrs.payer = event.repayer;
     attrs.borrower = event.borrower;
   } else if ('borrower' in event && !('liquidator' in event)) {
     attrs.borrower = event.borrower;

--- a/indexer/tests/unit/parser.test.ts
+++ b/indexer/tests/unit/parser.test.ts
@@ -286,10 +286,10 @@ describe('Event Parsers', () => {
     });
 
     describe('repay', () => {
-      it('parses repay event with repayer and borrower', () => {
+      it('parses repay event with payer and borrower', () => {
         const attributes = {
           action: 'repay',
-          repayer: ADDRESSES.userB,
+          payer: ADDRESSES.userB,
           borrower: ADDRESSES.userA,
           amount: DECIMALS.oneToken,
           scaled_decrease: DECIMALS.oneToken,


### PR DESCRIPTION
## Summary
- Fix indexer parser to read `payer` attribute instead of `repayer` for repay events
- The smart contract emits `payer` but the parser was looking for `repayer`, causing all repay events to fail with a missing `userAddress` error
- Update parser test to use the correct attribute name matching the contract
- Update `eventToRawAttributes` test helper to emit `payer` for consistency

## Test plan
- [x] Existing parser unit tests pass with updated attribute name
- [x] Existing repay handler unit tests pass
- [ ] Deploy to staging and verify repay events are indexed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)