### PR TITLE
Add transaction history dropdown

### DIFF
--- a/frontend/components/layout/Header.tsx
+++ b/frontend/components/layout/Header.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
+import { TransactionHistoryDropdown } from '@/components/transactions/TransactionHistoryDropdown';
 import { useWallet } from '@/lib/cosmjs/wallet';
 import { shortenAddress } from '@/lib/utils/format';
 
@@ -40,6 +41,7 @@ export function Header() {
                 <div className="hidden sm:block text-sm text-muted-foreground">
                   {shortenAddress(address!)}
                 </div>
+                <TransactionHistoryDropdown />
                 <Button variant="outline" onClick={disconnect} size="sm">
                   Disconnect
                 </Button>

--- a/frontend/components/transactions/TransactionHistoryDropdown.tsx
+++ b/frontend/components/transactions/TransactionHistoryDropdown.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useState, useRef, useEffect, useMemo } from 'react';
+import { History } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { TransactionItem } from './TransactionItem';
+import { usePendingTransactions } from '@/lib/contexts/TransactionContext';
+import { useTransactions } from '@/hooks/useTransactions';
+import { useWallet } from '@/lib/cosmjs/wallet';
+
+export function TransactionHistoryDropdown() {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const { address } = useWallet();
+  const { pendingTransactions, clearAllCompleted } = usePendingTransactions();
+  const { data: indexedTransactions } = useTransactions({
+    userAddress: address ?? undefined,
+    limit: 20,
+  });
+
+  // Close on click outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [isOpen]);
+
+  // Close on escape key
+  useEffect(() => {
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape);
+      return () => document.removeEventListener('keydown', handleEscape);
+    }
+  }, [isOpen]);
+
+  // Merge pending and indexed transactions, deduplicate by txHash
+  const allTransactions = useMemo(() => {
+    const pendingTxHashes = new Set(
+      pendingTransactions.filter((tx) => tx.txHash).map((tx) => tx.txHash)
+    );
+
+    // Filter indexed transactions that aren't already tracked as pending
+    const filteredIndexed = indexedTransactions.filter(
+      (tx) => !pendingTxHashes.has(tx.txHash)
+    );
+
+    // Convert indexed transactions to display format
+    const indexedForDisplay = filteredIndexed.map((tx) => ({
+      id: tx.id,
+      action: tx.action,
+      amount: tx.amount ?? '0',
+      denom: tx.debtDenom || tx.collateralDenom,
+      status: 'completed' as const,
+      timestamp: tx.timestamp,
+      txHash: tx.txHash,
+      error: undefined as string | undefined,
+    }));
+
+    // Convert pending transactions to display format
+    const pendingForDisplay = pendingTransactions.map((tx) => ({
+      id: tx.id,
+      action: tx.action,
+      amount: tx.amount,
+      denom: tx.denom,
+      status: tx.status,
+      timestamp: tx.timestamp,
+      txHash: tx.txHash,
+      error: tx.error,
+    }));
+
+    // Combine and sort by timestamp (newest first)
+    return [...pendingForDisplay, ...indexedForDisplay]
+      .sort((a, b) => {
+        const timeA = typeof a.timestamp === 'string' ? new Date(a.timestamp).getTime() : a.timestamp;
+        const timeB = typeof b.timestamp === 'string' ? new Date(b.timestamp).getTime() : b.timestamp;
+        return timeB - timeA;
+      })
+      .slice(0, 20);
+  }, [pendingTransactions, indexedTransactions]);
+
+  const pendingCount = pendingTransactions.filter((tx) => tx.status === 'pending').length;
+  const hasCompletedOrFailed = pendingTransactions.some((tx) => tx.status !== 'pending');
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={() => setIsOpen(!isOpen)}
+        className="relative"
+        aria-label="Transaction history"
+      >
+        <History className="h-4 w-4" />
+        {pendingCount > 0 && (
+          <span className="absolute -top-1 -right-1 h-4 w-4 rounded-full bg-primary text-[10px] font-medium text-primary-foreground flex items-center justify-center">
+            {pendingCount > 9 ? '9+' : pendingCount}
+          </span>
+        )}
+      </Button>
+
+      {isOpen && (
+        <div className="absolute right-0 mt-2 w-80 bg-background border border-border rounded-lg shadow-lg z-50">
+          <div className="flex items-center justify-between px-3 py-2.5 border-b border-border">
+            <h3 className="text-sm font-medium">Recent Transactions</h3>
+            {hasCompletedOrFailed && (
+              <button
+                onClick={clearAllCompleted}
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                Clear
+              </button>
+            )}
+          </div>
+
+          <div className="max-h-80 overflow-y-auto">
+            {allTransactions.length === 0 ? (
+              <div className="py-8 text-center">
+                <p className="text-sm text-muted-foreground">No transactions yet</p>
+              </div>
+            ) : (
+              <div className="divide-y divide-border">
+                {allTransactions.map((tx) => (
+                  <TransactionItem
+                    key={tx.id}
+                    action={tx.action}
+                    amount={tx.amount}
+                    denom={tx.denom}
+                    status={tx.status}
+                    timestamp={tx.timestamp}
+                    txHash={tx.txHash}
+                    error={tx.error}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/transactions/TransactionItem.tsx
+++ b/frontend/components/transactions/TransactionItem.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { Loader2, CheckCircle, XCircle, ExternalLink } from 'lucide-react';
+import { TransactionAction } from '@/lib/graphql/generated/hooks';
+import { TransactionStatus } from '@/lib/contexts/TransactionContext';
+import { formatDisplayAmount, formatDenom, microToBase } from '@/lib/utils/format';
+
+const ACTION_LABELS: Record<TransactionAction, string> = {
+  [TransactionAction.Supply]: 'Supply',
+  [TransactionAction.Withdraw]: 'Withdraw',
+  [TransactionAction.SupplyCollateral]: 'Supply Collateral',
+  [TransactionAction.WithdrawCollateral]: 'Withdraw Collateral',
+  [TransactionAction.Borrow]: 'Borrow',
+  [TransactionAction.Repay]: 'Repay',
+  [TransactionAction.Liquidate]: 'Liquidate',
+};
+
+export interface TransactionItemProps {
+  action: TransactionAction;
+  amount: string;
+  denom: string;
+  status: TransactionStatus;
+  timestamp: number | string;
+  txHash?: string;
+  error?: string;
+}
+
+function formatRelativeTime(timestamp: number | string): string {
+  const date = typeof timestamp === 'string' ? new Date(timestamp) : new Date(timestamp);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+
+  if (diffSec < 60) return 'Just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHour < 24) return `${diffHour}h ago`;
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return date.toLocaleDateString();
+}
+
+function StatusIcon({ status }: { status: TransactionStatus }) {
+  switch (status) {
+    case 'pending':
+      return <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />;
+    case 'completed':
+      return <CheckCircle className="h-4 w-4 text-green-500" />;
+    case 'failed':
+      return <XCircle className="h-4 w-4 text-destructive" />;
+  }
+}
+
+export function TransactionItem({
+  action,
+  amount,
+  denom,
+  status,
+  timestamp,
+  txHash,
+  error,
+}: TransactionItemProps) {
+  const displayAmount = amount.length > 10
+    ? formatDisplayAmount(microToBase(amount), 4)
+    : formatDisplayAmount(amount, 4);
+  const displayDenom = formatDenom(denom);
+
+  return (
+    <div className="flex items-center gap-3 px-3 py-2.5 hover:bg-muted/50 transition-colors">
+      <StatusIcon status={status} />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-sm font-medium truncate">
+            {ACTION_LABELS[action]}
+          </span>
+          <span className="text-xs text-muted-foreground whitespace-nowrap">
+            {formatRelativeTime(timestamp)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between gap-2 mt-0.5">
+          <span className="text-xs text-muted-foreground truncate">
+            {displayAmount} {displayDenom}
+          </span>
+          {txHash && (
+            <a
+              href={`https://www.mintscan.io/osmosis/tx/${txHash}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-muted-foreground hover:text-foreground transition-colors"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          )}
+        </div>
+        {status === 'failed' && error && (
+          <p className="text-xs text-destructive mt-1 truncate" title={error}>
+            {error}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/contexts/TransactionContext.tsx
+++ b/frontend/lib/contexts/TransactionContext.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+import { TransactionAction } from '@/lib/graphql/generated/hooks';
+
+export type TransactionStatus = 'pending' | 'completed' | 'failed';
+
+export interface PendingTransaction {
+  id: string;
+  txHash?: string;
+  action: TransactionAction;
+  amount: string;
+  denom: string;
+  marketAddress: string;
+  status: TransactionStatus;
+  timestamp: number;
+  error?: string;
+}
+
+interface TransactionContextType {
+  pendingTransactions: PendingTransaction[];
+  addPendingTransaction: (tx: Omit<PendingTransaction, 'id' | 'status' | 'timestamp'>) => string;
+  markCompleted: (id: string, txHash: string) => void;
+  markFailed: (id: string, error: string) => void;
+  clearTransaction: (id: string) => void;
+  clearAllCompleted: () => void;
+}
+
+const TransactionContext = createContext<TransactionContextType | undefined>(undefined);
+
+let transactionIdCounter = 0;
+
+function generateTransactionId(): string {
+  transactionIdCounter += 1;
+  return `tx-${Date.now()}-${transactionIdCounter}`;
+}
+
+export function TransactionProvider({ children }: { children: ReactNode }) {
+  const [pendingTransactions, setPendingTransactions] = useState<PendingTransaction[]>([]);
+
+  const addPendingTransaction = useCallback(
+    (tx: Omit<PendingTransaction, 'id' | 'status' | 'timestamp'>): string => {
+      const id = generateTransactionId();
+      const newTransaction: PendingTransaction = {
+        ...tx,
+        id,
+        status: 'pending',
+        timestamp: Date.now(),
+      };
+
+      setPendingTransactions((prev) => [newTransaction, ...prev].slice(0, 50));
+      return id;
+    },
+    []
+  );
+
+  const markCompleted = useCallback((id: string, txHash: string) => {
+    setPendingTransactions((prev) =>
+      prev.map((tx) =>
+        tx.id === id ? { ...tx, status: 'completed' as const, txHash } : tx
+      )
+    );
+  }, []);
+
+  const markFailed = useCallback((id: string, error: string) => {
+    setPendingTransactions((prev) =>
+      prev.map((tx) =>
+        tx.id === id ? { ...tx, status: 'failed' as const, error } : tx
+      )
+    );
+  }, []);
+
+  const clearTransaction = useCallback((id: string) => {
+    setPendingTransactions((prev) => prev.filter((tx) => tx.id !== id));
+  }, []);
+
+  const clearAllCompleted = useCallback(() => {
+    setPendingTransactions((prev) =>
+      prev.filter((tx) => tx.status === 'pending')
+    );
+  }, []);
+
+  return (
+    <TransactionContext.Provider
+      value={{
+        pendingTransactions,
+        addPendingTransaction,
+        markCompleted,
+        markFailed,
+        clearTransaction,
+        clearAllCompleted,
+      }}
+    >
+      {children}
+    </TransactionContext.Provider>
+  );
+}
+
+export function usePendingTransactions() {
+  const context = useContext(TransactionContext);
+  if (context === undefined) {
+    throw new Error('usePendingTransactions must be used within a TransactionProvider');
+  }
+  return context;
+}
+
+export { TransactionAction };

--- a/frontend/lib/providers.tsx
+++ b/frontend/lib/providers.tsx
@@ -3,6 +3,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ApolloProvider } from '@apollo/client/react/index.js';
 import { WalletProvider } from './cosmjs/wallet';
+import { TransactionProvider } from './contexts/TransactionContext';
 import { apolloClient } from './graphql/client';
 import { ReactNode, useState } from 'react';
 
@@ -22,7 +23,9 @@ export function Providers({ children }: { children: ReactNode }) {
   return (
     <ApolloProvider client={apolloClient}>
       <QueryClientProvider client={queryClient}>
-        <WalletProvider>{children}</WalletProvider>
+        <WalletProvider>
+          <TransactionProvider>{children}</TransactionProvider>
+        </WalletProvider>
       </QueryClientProvider>
     </ApolloProvider>
   );


### PR DESCRIPTION
## Summary
- Adds a transaction history dropdown button next to the Disconnect button in the Header
- Displays pending, completed, and failed transactions in a unified list
- Pending transactions show a spinner, completed show a checkmark, failed show an X
- Merges client-side pending transactions with indexed historical transactions
- Deduplicates by txHash and sorts by timestamp (newest first)

## Test plan
- [ ] Connect wallet and verify the history icon appears in the header
- [ ] Click the history button to open the dropdown
- [ ] Execute a transaction (Supply, Borrow, etc.) and verify it appears as pending with spinner
- [ ] Wait for transaction to complete and verify spinner changes to checkmark
- [ ] Test a failed transaction and verify X icon appears with error message
- [ ] Verify clicking outside the dropdown closes it
- [ ] Verify the "Clear" button removes completed/failed transactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)