### PR TITLE
feat: redesign Your Position tab with LTV health bar

### DIFF
--- a/frontend/app/markets/[id]/page.tsx
+++ b/frontend/app/markets/[id]/page.tsx
@@ -12,6 +12,8 @@ import { RepayModal } from '@/components/modals/RepayModal';
 import { WithdrawModal } from '@/components/modals/WithdrawModal';
 import { WithdrawCollateralModal } from '@/components/modals/WithdrawCollateralModal';
 import { AdvancedTab } from '@/components/markets/advanced';
+import { LtvHealthBar } from '@/components/markets/LtvHealthBar';
+import { PositionSummary } from '@/components/markets/PositionSummary';
 import { useMarket } from '@/hooks/useMarkets';
 import { useUserPosition } from '@/hooks/useUserPosition';
 import { useWallet } from '@/lib/cosmjs/wallet';
@@ -230,6 +232,15 @@ export default function MarketDetailPage() {
     : 0;
   const currentLtv = userCollateral > 0 && userDebt > 0 ? (userDebt / userCollateral) * 100 : 0;
 
+  // Ratio form (0-1) for position tab components
+  const currentLtvRatio = userCollateral > 0 && userDebt > 0 ? userDebt / userCollateral : 0;
+  const liquidationLtvRatio = market.params?.liquidation_threshold
+    ? parseFloat(market.params.liquidation_threshold)
+    : 0.86;
+
+  // Utilization as percentage for display
+  const utilizationPercent = market.utilization != null ? market.utilization : undefined;
+
   // Format large numbers
   const formatLargeNumber = (num: number) => {
     if (num >= 1000000000) return `$${(num / 1000000000).toFixed(2)}B`;
@@ -348,53 +359,21 @@ export default function MarketDetailPage() {
                     </CardContent>
                   </Card>
                 ) : (
-                  <div className="grid grid-cols-2 gap-4">
-                    <Card>
-                      <CardHeader className="pb-2">
-                        <CardTitle className="text-sm font-medium text-muted-foreground">
-                          Your Collateral
-                        </CardTitle>
-                      </CardHeader>
-                      <CardContent>
-                        <p className="text-2xl font-bold">
-                          {formatDisplayAmount(userCollateral)} {market.collateralDenom}
-                        </p>
-                      </CardContent>
-                    </Card>
-                    <Card>
-                      <CardHeader className="pb-2">
-                        <CardTitle className="text-sm font-medium text-muted-foreground">
-                          Your Debt
-                        </CardTitle>
-                      </CardHeader>
-                      <CardContent>
-                        <p className="text-2xl font-bold">
-                          {formatDisplayAmount(userDebt)} {market.debtDenom}
-                        </p>
-                      </CardContent>
-                    </Card>
-                    <Card>
-                      <CardHeader className="pb-2">
-                        <CardTitle className="text-sm font-medium text-muted-foreground">
-                          Current LTV
-                        </CardTitle>
-                      </CardHeader>
-                      <CardContent>
-                        <p className="text-2xl font-bold">{currentLtv.toFixed(1)}%</p>
-                      </CardContent>
-                    </Card>
-                    <Card>
-                      <CardHeader className="pb-2">
-                        <CardTitle className="text-sm font-medium text-muted-foreground">
-                          Health Factor
-                        </CardTitle>
-                      </CardHeader>
-                      <CardContent>
-                        <p className="text-2xl font-bold text-green-600">
-                          {position?.healthFactor?.toFixed(2) || '∞'}
-                        </p>
-                      </CardContent>
-                    </Card>
+                  <div className="space-y-6">
+                    <LtvHealthBar
+                      currentLtv={currentLtvRatio}
+                      liquidationLtv={liquidationLtvRatio}
+                    />
+                    <PositionSummary
+                      collateralAmount={userCollateral}
+                      collateralDenom={market.collateralDenom}
+                      debtAmount={userDebt}
+                      debtDenom={market.debtDenom}
+                      currentLtv={currentLtvRatio}
+                      liquidationLtv={liquidationLtvRatio}
+                      healthFactor={position?.healthFactor}
+                      utilization={utilizationPercent}
+                    />
                   </div>
                 )}
               </TabsContent>

--- a/frontend/components/markets/LtvHealthBar.tsx
+++ b/frontend/components/markets/LtvHealthBar.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+interface LtvHealthBarProps {
+  currentLtv: number;      // 0 to 1 (debt/collateral ratio)
+  liquidationLtv: number;  // 0 to 1 (e.g. 0.86)
+}
+
+function getBarColor(currentLtv: number, liquidationLtv: number): string {
+  if (liquidationLtv <= 0) return '#22c55e';
+  const ratio = currentLtv / liquidationLtv;
+  if (ratio <= 0.4) return '#22c55e';   // Green
+  if (ratio <= 0.65) return '#eab308';  // Yellow
+  if (ratio <= 0.85) return '#f97316';  // Orange
+  return '#ef4444';                      // Red
+}
+
+export function LtvHealthBar({ currentLtv, liquidationLtv }: LtvHealthBarProps) {
+  const hasPosition = currentLtv > 0;
+  const barColor = getBarColor(currentLtv, liquidationLtv);
+
+  // Fill percentage relative to the full bar (which represents 0 to liquidationLtv)
+  const fillPercent = liquidationLtv > 0
+    ? Math.min((currentLtv / liquidationLtv) * 100, 100)
+    : 0;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between text-sm">
+        <span className="text-muted-foreground">LTV</span>
+        <span className="text-muted-foreground">
+          Liquidation: {(liquidationLtv * 100).toFixed(0)}%
+        </span>
+      </div>
+
+      <div className="relative">
+        {/* Track */}
+        <div className="h-3 w-full rounded-full bg-muted overflow-hidden">
+          {hasPosition ? (
+            <div
+              className="h-full rounded-full transition-all duration-500 ease-out"
+              style={{
+                width: `${fillPercent}%`,
+                backgroundColor: barColor,
+              }}
+            />
+          ) : null}
+        </div>
+
+        {/* Liquidation threshold marker */}
+        <div
+          className="absolute top-0 h-3 w-0.5 bg-red-500/60"
+          style={{ left: '100%', transform: 'translateX(-2px)' }}
+          title={`Liquidation at ${(liquidationLtv * 100).toFixed(0)}%`}
+        />
+      </div>
+
+      {/* Labels */}
+      <div className="flex items-center justify-between text-sm">
+        {hasPosition ? (
+          <>
+            <span className="font-medium" style={{ color: barColor }}>
+              {(currentLtv * 100).toFixed(1)}%
+            </span>
+            <span className="text-muted-foreground text-xs">
+              {((1 - currentLtv / liquidationLtv) * 100).toFixed(0)}% buffer to liquidation
+            </span>
+          </>
+        ) : (
+          <span className="text-muted-foreground text-xs">No active position</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/markets/PositionSummary.tsx
+++ b/frontend/components/markets/PositionSummary.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { TokenIcon } from '@/components/ui/token-icon';
+import { formatDisplayAmount, getHealthFactorColor } from '@/lib/utils/format';
+import { Info } from 'lucide-react';
+
+interface PositionSummaryProps {
+  collateralAmount: string | number;
+  collateralDenom: string;
+  debtAmount: string | number;
+  debtDenom: string;
+  currentLtv: number;           // 0 to 1
+  liquidationLtv: number;       // 0 to 1
+  healthFactor?: number;
+  utilization?: number;         // 0 to 100
+  liquidationPrice?: number;
+  percentToLiquidation?: number;
+}
+
+function getLtvDotColor(currentLtv: number, liquidationLtv: number): string {
+  if (liquidationLtv <= 0 || currentLtv <= 0) return 'bg-gray-500';
+  const ratio = currentLtv / liquidationLtv;
+  if (ratio <= 0.4) return 'bg-green-500';
+  if (ratio <= 0.65) return 'bg-yellow-500';
+  if (ratio <= 0.85) return 'bg-orange-500';
+  return 'bg-red-500';
+}
+
+export function PositionSummary({
+  collateralAmount,
+  collateralDenom,
+  debtAmount,
+  debtDenom,
+  currentLtv,
+  liquidationLtv,
+  healthFactor,
+  utilization,
+  liquidationPrice,
+  percentToLiquidation,
+}: PositionSummaryProps) {
+  const collateralNum = typeof collateralAmount === 'string' ? parseFloat(collateralAmount) : collateralAmount;
+  const debtNum = typeof debtAmount === 'string' ? parseFloat(debtAmount) : debtAmount;
+  const ltvDotColor = getLtvDotColor(currentLtv, liquidationLtv);
+  const healthColor = getHealthFactorColor(healthFactor);
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8">
+      {/* Left column */}
+      <div>
+        {/* Collateral */}
+        <div className="flex items-center justify-between py-3 border-b border-border">
+          <span className="text-sm text-muted-foreground">Collateral</span>
+          <div className="flex items-center gap-2">
+            <TokenIcon symbol={collateralDenom} size="sm" />
+            <span className="text-sm font-medium">
+              {formatDisplayAmount(collateralNum)} {collateralDenom}
+            </span>
+          </div>
+        </div>
+
+        {/* Loan */}
+        <div className="flex items-center justify-between py-3 border-b border-border">
+          <span className="text-sm text-muted-foreground">Loan</span>
+          <div className="flex items-center gap-2">
+            <TokenIcon symbol={debtDenom} size="sm" />
+            <span className="text-sm font-medium">
+              {formatDisplayAmount(debtNum)} {debtDenom}
+            </span>
+          </div>
+        </div>
+
+        {/* LTV / Liquidation LTV */}
+        <div className="flex items-center justify-between py-3 border-b border-border md:border-b-0">
+          <span className="text-sm text-muted-foreground">LTV / Liquidation LTV</span>
+          <div className="flex items-center gap-2">
+            <div className={`w-2 h-2 rounded-full ${ltvDotColor}`} />
+            <span className="text-sm font-medium">
+              {currentLtv > 0 ? (currentLtv * 100).toFixed(1) : '0.0'}%
+              {' / '}
+              {(liquidationLtv * 100).toFixed(0)}%
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Right column */}
+      <div>
+        {/* Liquidation price */}
+        <div className="flex items-center justify-between py-3 border-b border-border">
+          <span className="text-sm text-muted-foreground">Liquidation price</span>
+          <span className="text-sm font-medium">
+            {liquidationPrice != null ? `$${formatDisplayAmount(liquidationPrice)}` : '-'}
+          </span>
+        </div>
+
+        {/* % drop to liquidation */}
+        <div className="flex items-center justify-between py-3 border-b border-border">
+          <span className="text-sm text-muted-foreground">% drop to liquidation</span>
+          <span className="text-sm font-medium">
+            {percentToLiquidation != null ? `${percentToLiquidation.toFixed(1)}%` : '-'}
+          </span>
+        </div>
+
+        {/* Utilization */}
+        <div className="flex items-center justify-between py-3">
+          <div className="flex items-center gap-1">
+            <span className="text-sm text-muted-foreground">Utilization</span>
+            <span title="Percentage of supplied assets currently being borrowed">
+              <Info className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
+            </span>
+          </div>
+          <span className="text-sm font-medium">
+            {utilization != null ? `${utilization.toFixed(1)}%` : '-'}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Feature
**ID:** FEATURE-001

## Changes
- New `LtvHealthBar` component — visual bar showing risk level (green→red)
- New `PositionSummary` component — Morpho-style clean two-column layout
- Replaced 2x2 card grid with modern position overview

## Design Reference
Morpho Blue UI style with added LTV health visualization bar.

## Screenshots
_To be verified locally_

## Testing
- [ ] Health bar colors correctly for different LTV levels
- [ ] Position summary displays all fields
- [ ] Disconnected wallet shows connect prompt
- [ ] No regression on other tabs