### PR TITLE
fix(security): add recipient address validation in borrow/withdraw paths

### DIFF
--- a/contracts/market/src/execute/borrow.rs
+++ b/contracts/market/src/execute/borrow.rs
@@ -68,15 +68,15 @@ pub fn execute_borrow(
     state.total_debt_scaled = state.total_debt_scaled.checked_add(scaled_amount)?;
     STATE.save(deps.storage, &state)?;
 
-    // Determine recipient
+    // Determine and validate recipient
     let recipient_addr = match recipient {
-        Some(addr) => addr,
-        None => info.sender.to_string(),
+        Some(addr) => deps.api.addr_validate(&addr)?,
+        None => info.sender.clone(),
     };
 
     // Create transfer message
     let transfer_msg = BankMsg::Send {
-        to_address: recipient_addr.clone(),
+        to_address: recipient_addr.to_string(),
         amount: vec![Coin {
             denom: config.debt_denom,
             amount,
@@ -95,7 +95,7 @@ pub fn execute_borrow(
         .add_message(transfer_msg)
         .add_attribute("action", "borrow")
         .add_attribute("borrower", info.sender)
-        .add_attribute("recipient", recipient_addr)
+        .add_attribute("recipient", recipient_addr.as_str())
         .add_attribute("amount", amount)
         .add_attribute("scaled_amount", scaled_amount)
         .add_attribute("borrow_index", state.borrow_index.to_string())
@@ -368,5 +368,33 @@ mod tests {
 
         let debt = DEBTS.load(deps.as_ref().storage, user1.as_str()).unwrap();
         assert_eq!(debt, Uint128::new(5000));
+    }
+
+    #[test]
+    fn test_borrow_with_invalid_recipient() {
+        // I-6 Fix: Invalid recipient address should be rejected
+        let mut deps = mock_dependencies();
+        setup_market_with_oracle(&mut deps);
+
+        let user1 = MockApi::default().addr_make("user1");
+        COLLATERAL
+            .save(deps.as_mut().storage, user1.as_str(), &Uint128::new(1000))
+            .unwrap();
+
+        let env = mock_env_at_time(0);
+        let info = message_info(&user1, &[]);
+
+        // Try to borrow with invalid recipient address
+        let err = execute_borrow(
+            deps.as_mut(),
+            env,
+            info,
+            Uint128::new(1000),
+            Some("invalid_address".to_string()),
+        )
+        .unwrap_err();
+
+        // Should fail with address validation error
+        assert!(matches!(err, ContractError::Std(_)));
     }
 }

--- a/contracts/market/src/execute/collateral.rs
+++ b/contracts/market/src/execute/collateral.rs
@@ -123,15 +123,15 @@ pub fn execute_withdraw_collateral(
     state.total_collateral = state.total_collateral.saturating_sub(withdraw_amount);
     STATE.save(deps.storage, &state)?;
 
-    // Determine recipient
+    // Determine and validate recipient
     let recipient_addr = match recipient {
-        Some(addr) => addr,
-        None => info.sender.to_string(),
+        Some(addr) => deps.api.addr_validate(&addr)?,
+        None => info.sender.clone(),
     };
 
     // Create transfer message
     let transfer_msg = BankMsg::Send {
-        to_address: recipient_addr.clone(),
+        to_address: recipient_addr.to_string(),
         amount: vec![Coin {
             denom: config.collateral_denom,
             amount: withdraw_amount,
@@ -142,7 +142,7 @@ pub fn execute_withdraw_collateral(
         .add_message(transfer_msg)
         .add_attribute("action", "withdraw_collateral")
         .add_attribute("user", info.sender)
-        .add_attribute("recipient", recipient_addr)
+        .add_attribute("recipient", recipient_addr.as_str())
         .add_attribute("amount", withdraw_amount))
 }
 
@@ -417,5 +417,39 @@ mod tests {
             .load(deps.as_ref().storage, user1.as_str())
             .unwrap();
         assert_eq!(remaining, Uint128::new(500));
+    }
+
+    #[test]
+    fn test_withdraw_collateral_with_invalid_recipient() {
+        // I-6 Fix: Invalid recipient address should be rejected
+        let mut deps = mock_dependencies();
+        setup_market(&mut deps);
+
+        let api = MockApi::default();
+        let user1 = api.addr_make("user1");
+
+        // Add collateral
+        COLLATERAL
+            .save(deps.as_mut().storage, user1.as_str(), &Uint128::new(1000))
+            .unwrap();
+        let mut state = STATE.load(deps.as_ref().storage).unwrap();
+        state.total_collateral = Uint128::new(1000);
+        STATE.save(deps.as_mut().storage, &state).unwrap();
+
+        let env = mock_env();
+        let info = message_info(&user1, &[]);
+
+        // Try to withdraw collateral with invalid recipient address
+        let err = execute_withdraw_collateral(
+            deps.as_mut(),
+            env,
+            info,
+            Some(Uint128::new(500)),
+            Some("invalid_address".to_string()),
+        )
+        .unwrap_err();
+
+        // Should fail with address validation error
+        assert!(matches!(err, ContractError::Std(_)));
     }
 }

--- a/contracts/market/src/execute/withdraw.rs
+++ b/contracts/market/src/execute/withdraw.rs
@@ -77,15 +77,15 @@ pub fn execute_withdraw(
     // Calculate current rates based on post-transaction state
     let (borrow_rate, liquidity_rate) = crate::interest::calculate_current_rates(deps.storage)?;
 
-    // Determine recipient
+    // Determine and validate recipient
     let recipient_addr = match recipient {
-        Some(addr) => addr,
-        None => info.sender.to_string(),
+        Some(addr) => deps.api.addr_validate(&addr)?,
+        None => info.sender.clone(),
     };
 
     // Create transfer message
     let transfer_msg = BankMsg::Send {
-        to_address: recipient_addr.clone(),
+        to_address: recipient_addr.to_string(),
         amount: vec![Coin {
             denom: config.debt_denom,
             amount: withdraw_amount,
@@ -96,7 +96,7 @@ pub fn execute_withdraw(
         .add_message(transfer_msg)
         .add_attribute("action", "withdraw")
         .add_attribute("withdrawer", info.sender)
-        .add_attribute("recipient", recipient_addr)
+        .add_attribute("recipient", recipient_addr.as_str())
         .add_attribute("amount", withdraw_amount)
         .add_attribute("scaled_decrease", scaled_decrease)
         .add_attribute("borrow_index", state.borrow_index.to_string())
@@ -335,5 +335,29 @@ mod tests {
             .load(deps.as_ref().storage, user1.as_str())
             .unwrap();
         assert_eq!(supply, Uint128::new(500));
+    }
+
+    #[test]
+    fn test_withdraw_with_invalid_recipient() {
+        // I-6 Fix: Invalid recipient address should be rejected
+        let mut deps = mock_dependencies();
+        setup_market_with_supply(&mut deps);
+
+        let env = mock_env();
+        let user1 = MockApi::default().addr_make("user1");
+        let info = message_info(&user1, &[]);
+
+        // Try to withdraw with invalid recipient address
+        let err = execute_withdraw(
+            deps.as_mut(),
+            env,
+            info,
+            Some(Uint128::new(500)),
+            Some("invalid_address".to_string()),
+        )
+        .unwrap_err();
+
+        // Should fail with address validation error
+        assert!(matches!(err, ContractError::Std(_)));
     }
 }


### PR DESCRIPTION
## What
Adds address validation for custom recipient addresses in borrow, withdraw, and withdraw_collateral execution paths.

## Why
Custom recipients were accepted without validation, unlike supply paths. Invalid addresses could be passed, leading to failed sends or lost funds (Issue #60).

## How
- Added `deps.api.addr_validate(\u0026addr)?` for any custom recipient address
- Updated recipient handling to use `Addr` type with proper string conversion for BankMsg

## Files Changed
- `contracts/market/src/execute/borrow.rs`
- `contracts/market/src/execute/withdraw.rs`
- `contracts/market/src/execute/collateral.rs`

## Testing
- All 99 tests pass
- Added 3 new tests verifying invalid addresses are rejected:
  - `test_borrow_with_invalid_recipient`
  - `test_withdraw_with_invalid_recipient`
  - `test_withdraw_collateral_with_invalid_recipient`
- `cargo clippy` passes

## Checklist
- [x] Code follows project conventions
- [x] Tests added for new validation
- [x] All tests pass
- [x] Commit follows conventional format
- [x] Closes #60

🤖 Implemented by Kimi