### PR TITLE
feat(frontend): integrate Pyth Hermes API for live price display (#107)

### DIFF
--- a/frontend/app/markets/page.tsx
+++ b/frontend/app/markets/page.tsx
@@ -21,7 +21,7 @@ export default function MarketsPage() {
     direction: 'desc',
   });
 
-  // Collect unique chain denoms from all markets for Pyth price fetch
+  // Collect all unique chain denoms across markets for a single Pyth fetch
   const allDenoms = useMemo(() => {
     const denomSet = new Set<string>();
     markets.forEach((m) => {

--- a/frontend/components/markets/MarketsTable.tsx
+++ b/frontend/components/markets/MarketsTable.tsx
@@ -17,6 +17,7 @@ import {
   formatUSD,
   microToBase,
 } from '@/lib/utils/format';
+import { getChainDenom } from '@/lib/utils/denom';
 import { ChevronUp, ChevronDown } from 'lucide-react';
 
 interface MarketsTableProps {
@@ -95,12 +96,6 @@ function TokenCell({ symbol }: { symbol: string }) {
   );
 }
 
-/** Map a display denom (e.g. "ATOM") back to the chain denom (e.g. "uatom"). */
-function toChainDenom(displayDenom: string): string {
-  const lower = displayDenom.toLowerCase();
-  return lower.startsWith('u') ? lower : `u${lower}`;
-}
-
 export function MarketsTable({
   markets,
   positionsMap,
@@ -177,8 +172,8 @@ export function MarketsTable({
               </TableCell>
               <TableCell className="text-right">
                 {(() => {
-                  const colPrice = pythPrices[toChainDenom(market.collateralDenom)];
-                  const debtPrice = pythPrices[toChainDenom(market.debtDenom)];
+                  const colPrice = pythPrices[getChainDenom(market.collateralDenom)];
+                  const debtPrice = pythPrices[getChainDenom(market.debtDenom)];
                   if (colPrice && debtPrice) {
                     return (
                       <span className="font-medium">
@@ -191,14 +186,15 @@ export function MarketsTable({
               </TableCell>
               <TableCell className="text-right">
                 <div>
-                  <span>{formatDisplayAmount(microToBase(market.totalSupplied), 0)} {market.debtDenom}</span>
+                  <span>
+                    {formatDisplayAmount(microToBase(market.totalSupplied), 0)} {market.debtDenom}
+                  </span>
                   {(() => {
-                    const debtPrice = pythPrices[toChainDenom(market.debtDenom)];
+                    const debtPrice = pythPrices[getChainDenom(market.debtDenom)];
                     if (debtPrice) {
-                      const usdValue = parseFloat(microToBase(market.totalSupplied)) * debtPrice;
                       return (
                         <div className="text-xs text-muted-foreground">
-                          {formatUSD(usdValue)}
+                          {formatUSD(parseFloat(microToBase(market.totalSupplied)) * debtPrice)}
                         </div>
                       );
                     }

--- a/frontend/components/markets/advanced/AdvancedTab.tsx
+++ b/frontend/components/markets/advanced/AdvancedTab.tsx
@@ -9,6 +9,7 @@ import { CollateralAtRisk } from './CollateralAtRisk';
 import { LiquidationHistory, LiquidationEvent } from './LiquidationHistory';
 import { parseIRMParams, IRMParams } from '@/lib/utils/irm';
 import { Position } from '@/lib/utils/collateral-risk';
+import { PythPrice } from '@/lib/pyth/client';
 import {
   MOCK_ADVANCED_MARKET_DATA,
   MOCK_IRM_PARAMS,
@@ -34,9 +35,24 @@ interface MarketData {
 
 export interface AdvancedTabProps {
   market: MarketData;
+  /** Pyth USD prices keyed by chain denom — passed from page level (review #3) */
+  pythPrices?: Record<string, number>;
+  pythRawPrices?: Record<string, PythPrice>;
+  pythLoading?: boolean;
+  pythError?: Error | null;
+  pythLastUpdated?: Date | null;
+  pythIsStale?: boolean;
 }
 
-export function AdvancedTab({ market }: AdvancedTabProps) {
+export function AdvancedTab({
+  market,
+  pythPrices,
+  pythRawPrices,
+  pythLoading,
+  pythError,
+  pythLastUpdated,
+  pythIsStale,
+}: AdvancedTabProps) {
   // Parse IRM params from market data or use mock
   const interestRateModel = market.params?.interest_rate_model;
   const irmParams: IRMParams = useMemo(() => {
@@ -70,7 +86,6 @@ export function AdvancedTab({ market }: AdvancedTabProps) {
   // TODO: These values require additional data sources
   // See advanced-tab-data-analysis.md for implementation details
   const oraclePrice = MOCK_ADVANCED_MARKET_DATA.oraclePrice;
-  const referencePrice = MOCK_ADVANCED_MARKET_DATA.referencePrice;
   const totalCollateral = market.totalCollateral
     ? parseFloat(market.totalCollateral)
     : totalSupply / oraclePrice; // Estimate
@@ -96,9 +111,13 @@ export function AdvancedTab({ market }: AdvancedTabProps) {
         oracleAddress={oracleAddress}
         collateralDenom={market.collateralDenom}
         debtDenom={market.debtDenom}
-        oraclePrice={oraclePrice}
-        referencePrice={referencePrice}
         valueSecured={valueSecured}
+        pythPrices={pythPrices}
+        pythRawPrices={pythRawPrices}
+        pythLoading={pythLoading}
+        pythError={pythError}
+        pythLastUpdated={pythLastUpdated}
+        pythIsStale={pythIsStale}
       />
 
       {/* Section 3: IRM Breakdown */}

--- a/frontend/components/markets/position/BorrowPosition.tsx
+++ b/frontend/components/markets/position/BorrowPosition.tsx
@@ -3,28 +3,23 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { formatDisplayAmount, formatUSD, microToBase } from '@/lib/utils/format';
 import { Market, UserPosition } from '@/types';
-import { usePythPrices } from '@/hooks/usePythPrices';
 import { getChainDenom } from '@/lib/utils/denom';
 
 interface BorrowPositionProps {
   position: UserPosition;
   market: Market;
+  /** Pyth USD prices keyed by chain denom — passed from page level (review #3) */
+  pythPrices?: Record<string, number>;
 }
 
-export function BorrowPosition({ position, market }: BorrowPositionProps) {
+export function BorrowPosition({ position, market, pythPrices = {} }: BorrowPositionProps) {
   const collateral = parseFloat(microToBase(position.collateralAmount));
   const debt = parseFloat(microToBase(position.debtAmount));
   const currentLtv = collateral > 0 && debt > 0 ? (debt / collateral) * 100 : 0;
   const health = position.healthFactor;
 
-  // Fetch Pyth prices
-  const { prices } = usePythPrices(
-    [getChainDenom(market.collateralDenom), getChainDenom(market.debtDenom)],
-    30000
-  );
-
-  const collateralPrice = prices[getChainDenom(market.collateralDenom)];
-  const debtPrice = prices[getChainDenom(market.debtDenom)];
+  const collateralPrice = pythPrices[getChainDenom(market.collateralDenom)];
+  const debtPrice = pythPrices[getChainDenom(market.debtDenom)];
 
   const collateralUSD = collateralPrice ? collateral * collateralPrice : null;
   const debtUSD = debtPrice ? debt * debtPrice : null;

--- a/frontend/components/markets/position/PositionDisplay.tsx
+++ b/frontend/components/markets/position/PositionDisplay.tsx
@@ -10,9 +10,11 @@ interface PositionDisplayProps {
   positionType: PositionType;
   market: Market;
   isConnected: boolean;
+  /** Pyth USD prices keyed by chain denom — passed from page level */
+  pythPrices?: Record<string, number>;
 }
 
-export function PositionDisplay({ position, positionType, market, isConnected }: PositionDisplayProps) {
+export function PositionDisplay({ position, positionType, market, isConnected, pythPrices }: PositionDisplayProps) {
   if (!isConnected) {
     return (
       <Card>
@@ -27,9 +29,9 @@ export function PositionDisplay({ position, positionType, market, isConnected }:
     case 'none':
       return <NoPosition />;
     case 'supply':
-      return <SupplyPosition position={position!} market={market} />;
+      return <SupplyPosition position={position!} market={market} pythPrices={pythPrices} />;
     case 'borrow':
-      return <BorrowPosition position={position!} market={market} />;
+      return <BorrowPosition position={position!} market={market} pythPrices={pythPrices} />;
     case 'both':
       return (
         <div className="space-y-4">
@@ -37,8 +39,8 @@ export function PositionDisplay({ position, positionType, market, isConnected }:
             <AlertTriangle className="h-4 w-4" />
             <p className="text-sm font-medium">You have both a supply and borrow position. Consider repaying your debt first.</p>
           </div>
-          <SupplyPosition position={position!} market={market} />
-          <BorrowPosition position={position!} market={market} />
+          <SupplyPosition position={position!} market={market} pythPrices={pythPrices} />
+          <BorrowPosition position={position!} market={market} pythPrices={pythPrices} />
         </div>
       );
     default:

--- a/frontend/components/markets/position/SupplyPosition.tsx
+++ b/frontend/components/markets/position/SupplyPosition.tsx
@@ -4,23 +4,22 @@ import { CardContent } from '@/components/ui/card';
 import { TokenIcon } from '@/components/ui/token-icon';
 import { UserPosition } from '@/types';
 import { formatDisplayAmount, formatPercentage, formatUSD, microToBase } from '@/lib/utils/format';
-import { usePythPrices } from '@/hooks/usePythPrices';
 import { getChainDenom } from '@/lib/utils/denom';
 
 interface SupplyPositionProps {
   position: UserPosition;
   market: { debtDenom: string; supplyApy: number };
+  /** Pyth USD prices keyed by chain denom — passed from page level (review #3) */
+  pythPrices?: Record<string, number>;
 }
 
-export function SupplyPosition({ position, market }: SupplyPositionProps) {
+export function SupplyPosition({ position, market, pythPrices = {} }: SupplyPositionProps) {
   const supplyDenom = market.debtDenom; // Supply is in the debt token
   const supplyApy = market.supplyApy;
   const supplyAmount = parseFloat(microToBase(position.supplyAmount));
   const estimatedYield = supplyAmount * (supplyApy / 100);
 
-  // Fetch Pyth price for the supply token
-  const { prices } = usePythPrices([getChainDenom(supplyDenom)], 30000);
-  const price = prices[getChainDenom(supplyDenom)];
+  const price = pythPrices[getChainDenom(supplyDenom)];
 
   const supplyUSD = price ? supplyAmount * price : null;
   const yieldUSD = price ? estimatedYield * price : null;

--- a/frontend/hooks/usePythPrices.ts
+++ b/frontend/hooks/usePythPrices.ts
@@ -1,53 +1,69 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { PYTH_FEED_IDS } from '@/lib/pyth/config';
+import { PYTH_FEED_IDS, PYTH_STALENESS_THRESHOLD_SECONDS } from '@/lib/pyth/config';
 import { fetchPythPrices, PythPrice } from '@/lib/pyth/client';
 
 interface PythPricesState {
-  prices: Record<string, number>;  // denom -> USD price
+  /** denom → USD price */
+  prices: Record<string, number>;
   isLoading: boolean;
   error: Error | null;
   lastUpdated: Date | null;
-  rawPrices: Record<string, PythPrice>; // denom -> full PythPrice
+  /** denom → full PythPrice (includes confidence, publishTime, etc.) */
+  rawPrices: Record<string, PythPrice>;
+  /** True when any returned price has a publishTime older than PYTH_STALENESS_THRESHOLD_SECONDS */
+  isStale: boolean;
 }
 
 /**
- * React hook for fetching and auto-refreshing Pyth prices
- * @param denoms Array of token denoms to fetch prices for (e.g., ['uatom', 'uusdc'])
- * @param refreshInterval Interval in milliseconds between refreshes (default: 15000 = 15s)
- * @returns Object with prices, loading state, error, and last updated timestamp
+ * Check whether a Pyth price is stale (older than the configured threshold).
+ */
+function isPriceStale(publishTime: number): boolean {
+  const ageSeconds = Math.floor(Date.now() / 1000) - publishTime;
+  return ageSeconds > PYTH_STALENESS_THRESHOLD_SECONDS;
+}
+
+/**
+ * React hook that fetches and auto-refreshes Pyth prices.
+ *
+ * @param denoms  Array of chain denoms (e.g. ['uatom', 'uusdc'])
+ * @param refreshInterval  Milliseconds between refreshes (default 15 000)
  */
 export function usePythPrices(
   denoms: string[],
-  refreshInterval: number = 15000
+  refreshInterval: number = 15000,
 ): PythPricesState {
   const [prices, setPrices] = useState<Record<string, number>>({});
   const [rawPrices, setRawPrices] = useState<Record<string, PythPrice>>({});
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
-  
+  const [isStale, setIsStale] = useState(false);
+
   // Use ref to track interval ID for cleanup
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   // Track if component is mounted to avoid state updates after unmount
   const isMountedRef = useRef(true);
 
   // Stabilise the denoms array so a new reference with identical contents
-  // doesn't trigger a re-fetch cascade.
+  // doesn't trigger a re-fetch cascade. Sort + join to create a stable key.
+  const denomsKey = useMemo(() => [...denoms].sort().join(','), [denoms]);
+
   const stableDenoms = useMemo(
     () => denoms,
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [denoms.join(',')]
+    [denomsKey],
   );
 
   const fetchPrices = useCallback(async () => {
     // Filter to only denoms we have feed IDs for
     const validDenoms = stableDenoms.filter((denom) => PYTH_FEED_IDS[denom]);
-    
+
     if (validDenoms.length === 0) {
       setPrices({});
       setRawPrices({});
+      setIsStale(false);
       return;
     }
 
@@ -63,27 +79,32 @@ export function usePythPrices(
       // Convert feed IDs back to denoms
       const pricesByDenom: Record<string, number> = {};
       const rawPricesByDenom: Record<string, PythPrice> = {};
+      let anyStale = false;
 
       for (const denom of validDenoms) {
         const feedId = PYTH_FEED_IDS[denom];
         const priceData = pricesByFeedId.get(feedId);
-        
+
         if (priceData) {
           pricesByDenom[denom] = priceData.price;
           rawPricesByDenom[denom] = priceData;
+          if (isPriceStale(priceData.publishTime)) {
+            anyStale = true;
+          }
         }
       }
 
       setPrices(pricesByDenom);
       setRawPrices(rawPricesByDenom);
       setLastUpdated(new Date());
+      setIsStale(anyStale);
       setError(null);
     } catch (err) {
       if (!isMountedRef.current) return;
-      
+
       // Don't break the UI - keep previous prices if available
       setError(err instanceof Error ? err : new Error('Failed to fetch prices'));
-      console.error('Pyth price fetch error:', err);
+      console.error('[usePythPrices] fetch error:', err);
     } finally {
       if (isMountedRef.current) {
         setIsLoading(false);
@@ -119,26 +140,27 @@ export function usePythPrices(
     error,
     lastUpdated,
     rawPrices,
+    isStale,
   };
 }
 
 /**
- * React hook for fetching a single Pyth price
- * @param denom Token denom to fetch price for (e.g., 'uatom')
- * @param refreshInterval Interval in milliseconds between refreshes
- * @returns Object with price, loading state, error, and last updated timestamp
+ * React hook for fetching a single Pyth price.
+ *
+ * @param denom  Token denom to fetch price for (e.g. 'uatom')
+ * @param refreshInterval  Interval in milliseconds between refreshes
  */
 export function usePythPrice(
   denom: string | undefined,
-  refreshInterval: number = 15000
-): Omit<PythPricesState, 'prices' | 'rawPrices'> & { 
-  price: number | null; 
+  refreshInterval: number = 15000,
+): Omit<PythPricesState, 'prices' | 'rawPrices'> & {
+  price: number | null;
   rawPrice: PythPrice | null;
 } {
-  const denoms = denom ? [denom] : [];
-  const { prices, rawPrices, isLoading, error, lastUpdated } = usePythPrices(
+  const denoms = useMemo(() => (denom ? [denom] : []), [denom]);
+  const { prices, rawPrices, isLoading, error, lastUpdated, isStale } = usePythPrices(
     denoms,
-    refreshInterval
+    refreshInterval,
   );
 
   return {
@@ -147,5 +169,6 @@ export function usePythPrice(
     isLoading,
     error,
     lastUpdated,
+    isStale,
   };
 }

--- a/frontend/lib/pyth/client.ts
+++ b/frontend/lib/pyth/client.ts
@@ -1,145 +1,127 @@
 import { PYTH_HERMES_URL, PYTH_FEED_ID_TO_DENOM } from './config';
 
 export interface PythPrice {
-  price: number;      // USD price
-  confidence: number; // confidence interval
-  expo: number;       // exponent
+  /** USD price (human-readable, e.g. 10.52) */
+  price: number;
+  /** Confidence interval in same units as price */
+  confidence: number;
+  /** Original exponent from the feed */
+  expo: number;
+  /** Unix timestamp (seconds) when the price was published */
   publishTime: number;
 }
 
-interface PythPriceResponse {
-  parsed: Array<{
-    id: string;
-    price: {
-      price: string;
-      conf: string;
-      expo: number;
-      publish_time: number;
-    };
-    ema_price?: {
-      price: string;
-      conf: string;
-      expo: number;
-      publish_time: number;
-    };
-  }>;
+interface HermesParsedEntry {
+  id: string;
+  price: {
+    price: string;
+    conf: string;
+    expo: number;
+    publish_time: number;
+  };
+  ema_price?: {
+    price: string;
+    conf: string;
+    expo: number;
+    publish_time: number;
+  };
+}
+
+interface HermesResponse {
+  parsed: HermesParsedEntry[];
   binary?: {
     data: string[];
     encoding: string;
   };
 }
 
+/** Default timeout for Hermes fetch calls (10 seconds). */
+const HERMES_FETCH_TIMEOUT_MS = 10_000;
+
 /**
- * Fetch latest prices from Pyth Hermes API
- * @param feedIds Array of Pyth feed IDs to fetch
- * @returns Map of feedId -> PythPrice
+ * Fetch latest prices from the Pyth Hermes REST API.
+ *
+ * @param feedIds - Array of hex feed IDs (without 0x prefix)
+ * @returns Map of feedId → PythPrice
  */
-export async function fetchPythPrices(feedIds: string[]): Promise<Map<string, PythPrice>> {
+export async function fetchPythPrices(
+  feedIds: string[],
+): Promise<Map<string, PythPrice>> {
   if (feedIds.length === 0) {
     return new Map();
   }
 
-  const params = feedIds.map((id) => `ids[]=${encodeURIComponent(id)}`).join('&');
+  const params = feedIds
+    .map((id) => `ids[]=${encodeURIComponent(id)}`)
+    .join('&');
   const url = `${PYTH_HERMES_URL}/v2/updates/price/latest?${params}`;
 
-  const response = await fetch(url, {
-    headers: {
-      Accept: 'application/json',
-    },
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), HERMES_FETCH_TIMEOUT_MS);
 
-  if (!response.ok) {
-    throw new Error(`Pyth API error: ${response.status} ${response.statusText}`);
-  }
-
-  const data: PythPriceResponse = await response.json();
-  const prices = new Map<string, PythPrice>();
-
-  for (const entry of data.parsed || []) {
-    const priceData = entry.price;
-    
-    // Convert: actualPrice = price * 10^expo
-    const rawPrice = BigInt(priceData.price);
-    const expo = priceData.expo;
-    const confidence = BigInt(priceData.conf);
-    
-    // Calculate actual price: rawPrice * 10^expo
-    const actualPrice = Number(rawPrice) * Math.pow(10, expo);
-    const actualConfidence = Number(confidence) * Math.pow(10, expo);
-
-    prices.set(entry.id, {
-      price: actualPrice,
-      confidence: actualConfidence,
-      expo: expo,
-      publishTime: priceData.publish_time,
+  try {
+    const response = await fetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
     });
-  }
 
-  return prices;
+    if (!response.ok) {
+      throw new Error(`Pyth Hermes error: ${response.status} ${response.statusText}`);
+    }
+
+    const data: HermesResponse = await response.json();
+    const prices = new Map<string, PythPrice>();
+
+    for (const entry of data.parsed ?? []) {
+      const { price: rawPrice, conf, expo, publish_time } = entry.price;
+
+      // actualPrice = parseInt(price) * 10^expo
+      const actualPrice = Number(rawPrice) * Math.pow(10, expo);
+      const actualConfidence = Number(conf) * Math.pow(10, expo);
+
+      prices.set(entry.id, {
+        price: actualPrice,
+        confidence: actualConfidence,
+        expo,
+        publishTime: publish_time,
+      });
+    }
+
+    return prices;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 
 /**
- * Get price by denom instead of feed ID
- * @param denoms Array of token denoms (e.g., 'uatom', 'uusdc')
- * @returns Map of denom -> PythPrice
+ * Fetch prices keyed by denom instead of feed ID.
  */
 export async function fetchPythPricesByDenom(
   denoms: string[],
-  feedIdMap: Record<string, string>
+  feedIdMap: Record<string, string>,
 ): Promise<Map<string, PythPrice>> {
-  const feedIds = denoms
-    .map((denom) => feedIdMap[denom])
-    .filter(Boolean);
+  const feedIds = denoms.map((d) => feedIdMap[d]).filter(Boolean);
+  const byFeedId = await fetchPythPrices(feedIds);
 
-  const pricesByFeedId = await fetchPythPrices(feedIds);
-  
-  // Convert feed IDs back to denoms
-  const pricesByDenom = new Map<string, PythPrice>();
-  for (const [feedId, price] of pricesByFeedId.entries()) {
+  const byDenom = new Map<string, PythPrice>();
+  for (const [feedId, price] of byFeedId.entries()) {
     const denom = PYTH_FEED_ID_TO_DENOM[feedId];
     if (denom) {
-      pricesByDenom.set(denom, price);
+      byDenom.set(denom, price);
     }
   }
-
-  return pricesByDenom;
+  return byDenom;
 }
 
 /**
- * Format a Pyth price with confidence interval
- * @param price PythPrice object
- * @param decimals Number of decimal places to show
- * @returns Formatted price string with confidence
+ * Format a Pyth price with confidence interval.
  */
 export function formatPriceWithConfidence(
   price: PythPrice,
-  decimals: number = 4
+  decimals: number = 4,
 ): string {
   const lower = price.price - price.confidence;
   const upper = price.price + price.confidence;
-  
+
   return `$${price.price.toFixed(decimals)} (${lower.toFixed(decimals)} - ${upper.toFixed(decimals)})`;
-}
-
-/**
- * Format timestamp to relative time string
- * @param timestamp Unix timestamp in seconds
- * @returns Relative time string (e.g., "2 mins ago")
- */
-export function formatRelativeTime(timestamp: number): string {
-  const now = Math.floor(Date.now() / 1000);
-  const diff = now - timestamp;
-
-  if (diff < 60) {
-    return 'just now';
-  } else if (diff < 3600) {
-    const mins = Math.floor(diff / 60);
-    return `${mins} min${mins > 1 ? 's' : ''} ago`;
-  } else if (diff < 86400) {
-    const hours = Math.floor(diff / 3600);
-    return `${hours} hour${hours > 1 ? 's' : ''} ago`;
-  } else {
-    const days = Math.floor(diff / 86400);
-    return `${days} day${days > 1 ? 's' : ''} ago`;
-  }
 }

--- a/frontend/lib/utils/format.ts
+++ b/frontend/lib/utils/format.ts
@@ -100,3 +100,23 @@ export function getHealthFactorStatus(healthFactor?: number): string {
   if (healthFactor >= 1.2) return 'Risky';
   return 'Danger';
 }
+
+/**
+ * Format a unix timestamp (seconds) to a human-readable relative string.
+ * e.g. "just now", "3 mins ago", "2 hours ago", "1 day ago"
+ */
+export function formatRelativeTime(timestamp: number): string {
+  const diff = Math.floor(Date.now() / 1000) - timestamp;
+
+  if (diff < 60) return 'just now';
+  if (diff < 3600) {
+    const mins = Math.floor(diff / 60);
+    return `${mins} min${mins > 1 ? 's' : ''} ago`;
+  }
+  if (diff < 86400) {
+    const hours = Math.floor(diff / 3600);
+    return `${hours} hour${hours > 1 ? 's' : ''} ago`;
+  }
+  const days = Math.floor(diff / 86400);
+  return `${days} day${days > 1 ? 's' : ''} ago`;
+}


### PR DESCRIPTION
## What

Integrate Pyth Network's Hermes API into the Stone frontend to display live USD prices across all market views, replacing hardcoded/placeholder oracle values.

## Why

The frontend previously showed `--` for oracle prices and had no USD value context for token amounts. Users need real-time price data to make informed lending/borrowing decisions.

## How

### New files
- **`lib/pyth/config.ts`** — Feed ID mapping (ATOM, USDC, STONE) and Hermes URL config
- **`lib/pyth/client.ts`** — Fetch-based Hermes REST client (`/v2/updates/price/latest`), parses `price * 10^expo` conversion, includes `formatRelativeTime` utility
- **`hooks/usePythPrices.ts`** — React hook with auto-refresh (default 15s), `useCallback`/`useRef` to avoid re-render loops, returns `{ prices, rawPrices, isLoading, error, lastUpdated }`
- **`lib/utils/denom.ts`** — `getChainDenom()` helper (display denom → chain denom)

### Updated components
| Component | Change |
|-----------|--------|
| `OracleAttributes` | Live Pyth price, confidence interval (±%), last updated timestamp, "Trusted by: Pyth" badge |
| `MarketsTable` | Oracle price ratio column (was `--`), USD sub-line under market size |
| `MarketCard` | USD values for total supplied/borrowed |
| `PositionSummary` | Optional `collateralUsdPrice`/`debtUsdPrice` props for USD display |
| `BorrowPosition` | USD values for collateral and debt via `usePythPrices` |
| `SupplyPosition` | USD values for supply and estimated yield |
| `markets/[id]/page.tsx` | Stats row shows USD parentheticals, live oracle price in overview |
| `markets/page.tsx` | Single `usePythPrices` call for all market denoms, passed to table/cards |

### Error handling
- If Hermes is unreachable, previous prices are retained and UI remains functional
- Error banner shown in OracleAttributes when fetch fails
- Console warning logged on error — no user-facing crashes

## Testing
- [x] `npm run build` succeeds with zero TypeScript errors
- [x] All new props are optional — existing component usage is unaffected
- [x] Graceful fallback when no price data available (`--` / `N/A`)

## Checklist
- [x] Code follows project conventions (shadcn/ui, TypeScript)
- [x] No unrelated changes included
- [x] Commit message follows conventional format

Closes #107

🤖 Implemented by Claude (Anthropic)