### PR TITLE
fix(frontend): resolve TypeScript error in BorrowPosition component

### DIFF
--- a/frontend/components/markets/position/BorrowPosition.tsx
+++ b/frontend/components/markets/position/BorrowPosition.tsx
@@ -2,13 +2,18 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { formatDisplayAmount, formatUSD, microToBase } from '@/lib/utils/format';
-import { Market, UserPosition } from '@/types';
+import { Market, MarketDetail, UserPosition } from '@/types';
 import { getChainDenom } from '@/lib/utils/denom';
 import { computeHealthFactor, computeLtv } from '@/lib/utils/position';
 
+/** Type guard to check if market has params (is MarketDetail) */
+function isMarketDetail(market: Market | MarketDetail): market is MarketDetail {
+  return 'params' in market && market.params !== undefined;
+}
+
 interface BorrowPositionProps {
   position: UserPosition;
-  market: Market;
+  market: Market | MarketDetail;
   /** Pyth USD prices keyed by chain denom — passed from page level (review #3) */
   pythPrices?: Record<string, number>;
 }
@@ -26,7 +31,7 @@ export function BorrowPosition({ position, market, pythPrices = {} }: BorrowPosi
   const currentLtv = computeLtv(debt, collateral, debtPrice, collateralPrice);
 
   const liquidationThreshold =
-    'params' in market && market.params?.liquidation_threshold
+    isMarketDetail(market) && market.params?.liquidation_threshold
       ? parseFloat(market.params.liquidation_threshold)
       : undefined;
 

--- a/frontend/components/markets/position/PositionDisplay.tsx
+++ b/frontend/components/markets/position/PositionDisplay.tsx
@@ -1,5 +1,5 @@
 import { Card, CardContent } from '@/components/ui/card';
-import { Market, PositionType, UserPosition } from '@/types';
+import { Market, MarketDetail, PositionType, UserPosition } from '@/types';
 import { NoPosition } from './NoPosition';
 import { SupplyPosition } from './SupplyPosition';
 import { BorrowPosition } from './BorrowPosition';
@@ -8,7 +8,7 @@ import { AlertTriangle } from 'lucide-react';
 interface PositionDisplayProps {
   position: UserPosition | null;
   positionType: PositionType;
-  market: Market;
+  market: Market | MarketDetail;
   isConnected: boolean;
   /** Pyth USD prices keyed by chain denom — passed from page level */
   pythPrices?: Record<string, number>;


### PR DESCRIPTION
## What
Fix TypeScript build failure in the frontend caused by accessing `params.liquidation_threshold` on a `Market` type that doesn't have this property.

## Why
The build was failing with:
```
Type error: Property 'liquidation_threshold' does not exist on type '{}'.
```

This happened because `BorrowPosition` was typed to accept `Market`, but it tried to access `market.params?.liquidation_threshold` which only exists on `MarketDetail`.

## How
- Added `isMarketDetail` type guard function for proper TypeScript type narrowing
- Updated `BorrowPositionProps` to accept `Market | MarketDetail` union type
- Updated `PositionDisplayProps` to pass through the union type

This maintains backward compatibility — the component still works with both `Market` and `MarketDetail` objects, but now TypeScript understands the type narrowing.

## Testing
- [x] `npm run build` passes completely
- [x] No TypeScript errors

## Checklist
- [x] Code follows project conventions
- [x] Commit messages follow conventional format
- [x] No unrelated changes included

🤖 Implemented by Claude (Anthropic)