### PR TITLE
fix(indexer): parse withdraw_collateral 'user' attribute correctly

### DIFF
--- a/indexer/src/events/parser.ts
+++ b/indexer/src/events/parser.ts
@@ -137,7 +137,7 @@ export function parseMarketEvent(
     case 'withdraw_collateral':
       return {
         action: 'withdraw_collateral',
-        withdrawer: attributes.withdrawer,
+        withdrawer: attributes.user, // Contract emits 'user', not 'withdrawer'
         recipient: attributes.recipient,
         amount: attributes.amount,
         marketAddress,

--- a/indexer/tests/unit/parser.test.ts
+++ b/indexer/tests/unit/parser.test.ts
@@ -233,9 +233,11 @@ describe('Event Parsers', () => {
 
     describe('withdraw_collateral', () => {
       it('parses withdraw_collateral event', () => {
+        // Contract emits 'user' attribute (not 'withdrawer')
+        // See: contracts/market/src/execute/collateral.rs
         const attributes = {
           action: 'withdraw_collateral',
-          withdrawer: ADDRESSES.userA,
+          user: ADDRESSES.userA,
           recipient: ADDRESSES.userB,
           amount: DECIMALS.oneToken,
         };
@@ -251,6 +253,7 @@ describe('Event Parsers', () => {
 
         expect(result).not.toBeNull();
         expect(result!.action).toBe('withdraw_collateral');
+        // Parser maps 'user' to 'withdrawer' for consistency
         expect((result as any).withdrawer).toBe(ADDRESSES.userA);
         expect((result as any).recipient).toBe(ADDRESSES.userB);
       });


### PR DESCRIPTION
## What
Fix indexer crash on `withdraw_collateral` events by reading the correct contract attribute.

## Why
The contract emits `user` attribute but the parser expected `withdrawer`, causing crashes when processing withdrawal events.

**Contract** (`contracts/market/src/execute/collateral.rs` line ~127):
```rust
.add_attribute("user", info.sender)
```

**Parser was expecting**:
```typescript
withdrawer: attributes.withdrawer,  // WRONG - attribute doesn't exist
```

## How
Updated the parser to read from `attributes.user` and map it to the `withdrawer` field for consistency with other withdrawal event types.

Also verified all other event handlers for similar mismatches - they are all consistent.

## Testing
- [x] Updated unit test to use correct attribute name
- [x] Verified other handlers (`supply`, `withdraw`, `borrow`, `repay`, `liquidate`, etc.) are consistent

## Checklist
- [x] Code follows project conventions
- [x] Commit messages follow conventional format
- [x] No unrelated changes included

---

🤖 Implemented by Claude (Anthropic)