### PR TITLE
feat(frontend): rebuild oracle debug dashboard to query contracts

### DIFF
--- a/frontend/app/debug/oracle/page.tsx
+++ b/frontend/app/debug/oracle/page.tsx
@@ -10,19 +10,32 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { usePythPrices } from '@/hooks/usePythPrices';
 import {
-  DEFAULT_PYTH_FEEDS,
-  PYTH_HERMES_URL,
-  PYTH_CONTRACT_ADDRESS,
-  PYTH_MODE,
-  PYTH_STALENESS_THRESHOLD_SECONDS,
-} from '@/lib/pyth/config';
-import { AlertTriangle, CheckCircle, RefreshCw, ExternalLink, Copy } from 'lucide-react';
-import { useState, useEffect } from 'react';
+  useMultipleOracleQueries,
+  OracleState,
+  getPriceStatus,
+  getStatusEmoji,
+  STALENESS_STALE_THRESHOLD,
+} from '@/hooks/useOracleQuery';
+import { useGetMarketsQuery } from '@/lib/graphql/generated/hooks';
+import { getDisplaySymbol } from '@/lib/utils/denom-registry';
+import { RPC_ENDPOINT, CHAIN_ID } from '@/lib/constants';
+import { AlertTriangle, CheckCircle, RefreshCw, ExternalLink, Copy, Database } from 'lucide-react';
+import { useState, useEffect, useMemo } from 'react';
 
-// All denoms configured in the Pyth feeds
-const ALL_DENOMS = Object.keys(DEFAULT_PYTH_FEEDS);
+// Helper to generate explorer URL for contract addresses
+function getExplorerUrl(address: string): string {
+  // Determine explorer based on chain ID prefix
+  if (CHAIN_ID.includes('neutron')) {
+    return `https://neutron.celat.one/neutron-1/contracts/${address}`;
+  } else if (CHAIN_ID.includes('osmo')) {
+    return `https://celatone.osmosis.zone/osmo-test-5/contracts/${address}`;
+  } else if (CHAIN_ID.includes('pion')) {
+    return `https://neutron.celat.one/pion-1/contracts/${address}`;
+  }
+  // Default fallback for local chains - just show the address
+  return `#`;
+}
 
 function formatTimestamp(unixSeconds: number): string {
   return new Date(unixSeconds * 1000).toLocaleString();
@@ -32,10 +45,16 @@ function formatAge(unixSeconds: number): string {
   const now = Math.floor(Date.now() / 1000);
   const ageSeconds = now - unixSeconds;
 
+  if (ageSeconds < 0) return 'future?';
   if (ageSeconds < 60) return `${ageSeconds}s ago`;
   if (ageSeconds < 3600) return `${Math.floor(ageSeconds / 60)}m ${ageSeconds % 60}s ago`;
   if (ageSeconds < 86400) return `${Math.floor(ageSeconds / 3600)}h ${Math.floor((ageSeconds % 3600) / 60)}m ago`;
   return `${Math.floor(ageSeconds / 86400)}d ago`;
+}
+
+function shortenAddress(address: string, chars: number = 8): string {
+  if (address.length <= chars * 2 + 3) return address;
+  return `${address.slice(0, chars)}...${address.slice(-chars)}`;
 }
 
 function shortenFeedId(feedId: string): string {
@@ -47,21 +66,350 @@ function copyToClipboard(text: string) {
   navigator.clipboard.writeText(text);
 }
 
+// Parse price from string (handle scientific notation and decimal formats)
+function parsePrice(priceStr: string): number {
+  // Oracle returns prices in a specific format, typically as a decimal string
+  const parsed = parseFloat(priceStr);
+  if (isNaN(parsed)) return 0;
+  return parsed;
+}
+
+function formatPrice(price: number): string {
+  if (price === 0) return '$0.00';
+  if (price < 0.0001) return `$${price.toExponential(4)}`;
+  if (price < 1) return `$${price.toFixed(6)}`;
+  if (price < 100) return `$${price.toFixed(4)}`;
+  return `$${price.toFixed(2)}`;
+}
+
+// Format max confidence ratio (stored as decimal like "0.01" for 1%)
+function formatConfidenceRatio(ratio: string): string {
+  const parsed = parseFloat(ratio);
+  if (isNaN(parsed)) return ratio;
+  return `${(parsed * 100).toFixed(2)}%`;
+}
+
+interface OracleCardProps {
+  oracleAddress: string;
+  state: OracleState;
+  markets: Array<{
+    id: string;
+    address: string;
+    collateralDenom: string;
+    debtDenom: string;
+  }>;
+  now: number;
+}
+
+function OracleCard({ oracleAddress, state, markets, now }: OracleCardProps) {
+  const explorerUrl = getExplorerUrl(oracleAddress);
+  const isLocalChain = explorerUrl === '#';
+
+  // Get unique denoms for this oracle across all markets
+  const relevantDenoms = useMemo(() => {
+    const denoms = new Set<string>();
+    markets.forEach(m => {
+      denoms.add(m.collateralDenom);
+      denoms.add(m.debtDenom);
+    });
+    return Array.from(denoms);
+  }, [markets]);
+
+  // Check if any prices are stale
+  const hasStalePrice = useMemo(() => {
+    for (const denom of relevantDenoms) {
+      const price = state.prices.get(denom);
+      if (price) {
+        const age = now - price.updated_at;
+        if (age > STALENESS_STALE_THRESHOLD) return true;
+      }
+      if (state.priceErrors.has(denom)) return true;
+    }
+    return false;
+  }, [relevantDenoms, state.prices, state.priceErrors, now]);
+
+  return (
+    <Card className={hasStalePrice ? 'border-yellow-500/50' : ''}>
+      <CardHeader className="pb-4">
+        <CardTitle className="text-base font-medium flex items-center gap-2">
+          <Database className="h-4 w-4" />
+          Oracle Contract
+          {state.isLoading && <RefreshCw className="h-4 w-4 animate-spin text-blue-500" />}
+          {hasStalePrice && !state.isLoading && (
+            <span className="text-yellow-500 text-sm font-normal flex items-center gap-1">
+              <AlertTriangle className="h-3 w-3" />
+              Issues detected
+            </span>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* Oracle Address */}
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-muted-foreground">Address:</span>
+          <code className="font-mono bg-muted px-2 py-0.5 rounded">
+            {shortenAddress(oracleAddress, 12)}
+          </code>
+          <button
+            onClick={() => copyToClipboard(oracleAddress)}
+            className="text-muted-foreground hover:text-foreground p-1"
+            title="Copy address"
+          >
+            <Copy className="h-3 w-3" />
+          </button>
+          {!isLocalChain && (
+            <a
+              href={explorerUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-500 hover:text-blue-400 p-1"
+              title="View on explorer"
+            >
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          )}
+        </div>
+
+        {/* Config Section */}
+        <div>
+          <h4 className="text-sm font-medium mb-2">Configuration</h4>
+          {state.configError ? (
+            <div className="text-sm text-red-500 bg-red-500/10 border border-red-500/30 rounded p-2">
+              Failed to load config: {state.configError}
+            </div>
+          ) : state.config ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm">
+              <div>
+                <span className="text-muted-foreground">Pyth Contract:</span>{' '}
+                <code className="font-mono text-xs">{shortenAddress(state.config.pyth_contract_addr, 10)}</code>
+              </div>
+              <div>
+                <span className="text-muted-foreground">Max Confidence Ratio:</span>{' '}
+                <span className="font-mono">{formatConfidenceRatio(state.config.max_confidence_ratio)}</span>
+              </div>
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground">Loading...</div>
+          )}
+        </div>
+
+        {/* Markets using this oracle */}
+        <div>
+          <h4 className="text-sm font-medium mb-2">Markets Using This Oracle</h4>
+          <div className="flex flex-wrap gap-2">
+            {markets.map(m => (
+              <span
+                key={m.id}
+                className="text-xs bg-muted px-2 py-1 rounded font-mono"
+              >
+                {getDisplaySymbol(m.collateralDenom)}/{getDisplaySymbol(m.debtDenom)}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* Configured Feeds */}
+        <div>
+          <h4 className="text-sm font-medium mb-2">Configured Price Feeds</h4>
+          {state.priceFeedsError ? (
+            <div className="text-sm text-red-500 bg-red-500/10 border border-red-500/30 rounded p-2">
+              Failed to load feeds: {state.priceFeedsError}
+            </div>
+          ) : state.priceFeeds.length > 0 ? (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Denom</TableHead>
+                    <TableHead>Symbol</TableHead>
+                    <TableHead>Pyth Feed ID</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {state.priceFeeds.map((feed) => (
+                    <TableRow key={feed.denom}>
+                      <TableCell className="font-mono text-xs">{shortenAddress(feed.denom, 10)}</TableCell>
+                      <TableCell>{getDisplaySymbol(feed.denom)}</TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-1">
+                          <code className="text-xs text-muted-foreground">
+                            {shortenFeedId(feed.feed_id)}
+                          </code>
+                          <button
+                            onClick={() => copyToClipboard(feed.feed_id)}
+                            className="text-muted-foreground hover:text-foreground p-1"
+                            title="Copy feed ID"
+                          >
+                            <Copy className="h-3 w-3" />
+                          </button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground">No price feeds configured</div>
+          )}
+        </div>
+
+        {/* Live Prices */}
+        <div>
+          <h4 className="text-sm font-medium mb-2">Live Prices (What Markets See)</h4>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Denom</TableHead>
+                  <TableHead>Symbol</TableHead>
+                  <TableHead className="text-right">Price (USD)</TableHead>
+                  <TableHead>Updated At</TableHead>
+                  <TableHead>Staleness</TableHead>
+                  <TableHead>Error</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {relevantDenoms.map((denom) => {
+                  const price = state.prices.get(denom);
+                  const error = state.priceErrors.get(denom);
+                  const status = getPriceStatus(
+                    price?.updated_at ?? null,
+                    !!error
+                  );
+                  const ageSeconds = price ? now - price.updated_at : null;
+
+                  return (
+                    <TableRow 
+                      key={denom}
+                      className={status === 'stale' || status === 'error' ? 'bg-red-500/5' : status === 'warning' ? 'bg-yellow-500/5' : ''}
+                    >
+                      <TableCell>
+                        <span title={status} className="text-lg">
+                          {getStatusEmoji(status)}
+                        </span>
+                      </TableCell>
+                      <TableCell className="font-mono text-xs">
+                        {denom.startsWith('ibc/') ? shortenAddress(denom, 8) : denom}
+                      </TableCell>
+                      <TableCell className="font-medium">{getDisplaySymbol(denom)}</TableCell>
+                      <TableCell className="text-right font-mono">
+                        {price ? (
+                          formatPrice(parsePrice(price.price))
+                        ) : error ? (
+                          <span className="text-muted-foreground">—</span>
+                        ) : (
+                          <span className="text-muted-foreground">Loading...</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-xs text-muted-foreground font-mono">
+                        {price ? formatTimestamp(price.updated_at) : '—'}
+                      </TableCell>
+                      <TableCell className="font-mono">
+                        {ageSeconds !== null ? (
+                          <span className={status === 'stale' ? 'text-red-500 font-medium' : status === 'warning' ? 'text-yellow-500' : ''}>
+                            {formatAge(price!.updated_at)}
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        {error ? (
+                          <span className="text-xs text-red-500 bg-red-500/10 px-2 py-0.5 rounded">
+                            {error}
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 export default function OracleDebugPage() {
-  const { prices, rawPrices, isLoading, error, lastUpdated, isStale } = usePythPrices(
-    ALL_DENOMS,
-    10000 // Refresh every 10 seconds for debug view
+  // Fetch markets from GraphQL
+  const { data: marketsData, loading: marketsLoading, error: marketsError } = useGetMarketsQuery({
+    variables: {
+      limit: 100,
+      enabledOnly: false,
+    },
+  });
+
+  // Build oracle configs from markets
+  const oracleConfigs = useMemo(() => {
+    if (!marketsData?.markets) return [];
+
+    // Group markets by oracle address
+    const oracleMap = new Map<string, string[]>();
+    marketsData.markets.forEach(market => {
+      const existing = oracleMap.get(market.oracle) || [];
+      oracleMap.set(market.oracle, [
+        ...existing,
+        market.collateralDenom,
+        market.debtDenom,
+      ]);
+    });
+
+    return Array.from(oracleMap.entries()).map(([address, denoms]) => ({
+      address,
+      denoms: [...new Set(denoms)],
+    }));
+  }, [marketsData?.markets]);
+
+  // Query all oracles
+  const { oracles, isLoading: oraclesLoading, lastUpdated } = useMultipleOracleQueries(
+    oracleConfigs,
+    10000 // Refresh every 10 seconds
   );
 
+  // Keep track of current time for staleness calculations
   const [now, setNow] = useState(Math.floor(Date.now() / 1000));
-
-  // Update "now" every second to keep age display accurate
   useEffect(() => {
     const interval = setInterval(() => {
       setNow(Math.floor(Date.now() / 1000));
     }, 1000);
     return () => clearInterval(interval);
   }, []);
+
+  // Group markets by oracle
+  const marketsByOracle = useMemo(() => {
+    const markets = marketsData?.markets;
+    if (!markets) return new Map<string, typeof markets>();
+
+    const map = new Map<string, typeof markets>();
+    markets.forEach(market => {
+      const existing = map.get(market.oracle) || [];
+      map.set(market.oracle, [...existing, market]);
+    });
+    return map;
+  }, [marketsData]);
+
+  // Count issues
+  const issueCount = useMemo(() => {
+    let count = 0;
+    oracles.forEach(state => {
+      if (state.configError) count++;
+      if (state.priceFeedsError) count++;
+      state.priceErrors.forEach(() => count++);
+      state.prices.forEach(price => {
+        const age = now - price.updated_at;
+        if (age > STALENESS_STALE_THRESHOLD) count++;
+      });
+    });
+    return count;
+  }, [oracles, now]);
+
+  const isLoading = marketsLoading || oraclesLoading;
 
   return (
     <div className="min-h-screen bg-background">
@@ -72,47 +420,9 @@ export default function OracleDebugPage() {
         <div className="mb-8">
           <h1 className="text-4xl font-bold mb-2">🔮 Oracle Debug Dashboard</h1>
           <p className="text-muted-foreground">
-            Real-time Pyth oracle prices used by the Stone protocol
+            Live oracle contract state — what the market contracts actually see
           </p>
         </div>
-
-        {/* Configuration Card */}
-        <Card className="mb-6">
-          <CardHeader className="pb-4">
-            <CardTitle className="text-base font-medium">Pyth Configuration</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 text-sm">
-              <div>
-                <span className="text-muted-foreground">Mode:</span>{' '}
-                <span className={`font-mono ${PYTH_MODE === 'live' ? 'text-green-600' : 'text-yellow-600'}`}>
-                  {PYTH_MODE}
-                </span>
-              </div>
-              <div>
-                <span className="text-muted-foreground">Hermes URL:</span>{' '}
-                <a
-                  href={PYTH_HERMES_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="font-mono text-blue-600 hover:underline"
-                >
-                  {PYTH_HERMES_URL.replace('https://', '')}
-                </a>
-              </div>
-              <div>
-                <span className="text-muted-foreground">Contract:</span>{' '}
-                <span className="font-mono">
-                  {PYTH_CONTRACT_ADDRESS ? shortenFeedId(PYTH_CONTRACT_ADDRESS) : 'Not configured'}
-                </span>
-              </div>
-              <div>
-                <span className="text-muted-foreground">Staleness threshold:</span>{' '}
-                <span className="font-mono">{PYTH_STALENESS_THRESHOLD_SECONDS}s</span>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
 
         {/* Status Card */}
         <Card className="mb-6">
@@ -125,192 +435,149 @@ export default function OracleDebugPage() {
           <CardContent>
             <div className="flex flex-wrap gap-6 text-sm">
               <div className="flex items-center gap-2">
-                {error ? (
+                {marketsError ? (
                   <AlertTriangle className="h-4 w-4 text-red-500" />
                 ) : (
                   <CheckCircle className="h-4 w-4 text-green-500" />
                 )}
                 <span>
-                  {error ? 'Error fetching prices' : 'Connected to Pyth'}
+                  {marketsError ? 'Error loading markets' : 'Connected'}
                 </span>
               </div>
 
-              {isStale && (
-                <div className="flex items-center gap-2 text-yellow-600">
-                  <AlertTriangle className="h-4 w-4" />
-                  <span>Some prices are stale</span>
-                </div>
-              )}
+              <div>
+                <span className="text-muted-foreground">RPC:</span>{' '}
+                <span className="font-mono text-xs">{RPC_ENDPOINT}</span>
+              </div>
 
               <div>
-                <span className="text-muted-foreground">Last fetch:</span>{' '}
+                <span className="text-muted-foreground">Chain:</span>{' '}
+                <span className="font-mono">{CHAIN_ID}</span>
+              </div>
+
+              <div>
+                <span className="text-muted-foreground">Markets:</span>{' '}
+                <span className="font-mono">{marketsData?.markets?.length ?? 0}</span>
+              </div>
+
+              <div>
+                <span className="text-muted-foreground">Oracles:</span>{' '}
+                <span className="font-mono">{oracles.size}</span>
+              </div>
+
+              <div>
+                <span className="text-muted-foreground">Last refresh:</span>{' '}
                 <span className="font-mono">
                   {lastUpdated ? formatAge(Math.floor(lastUpdated.getTime() / 1000)) : 'Never'}
                 </span>
               </div>
 
-              <div>
-                <span className="text-muted-foreground">Feeds configured:</span>{' '}
-                <span className="font-mono">{ALL_DENOMS.length}</span>
-              </div>
-
-              <div>
-                <span className="text-muted-foreground">Prices loaded:</span>{' '}
-                <span className="font-mono">{Object.keys(prices).length}</span>
-              </div>
+              {issueCount > 0 && (
+                <div className="flex items-center gap-2 text-yellow-600">
+                  <AlertTriangle className="h-4 w-4" />
+                  <span>{issueCount} issue{issueCount > 1 ? 's' : ''} detected</span>
+                </div>
+              )}
             </div>
 
-            {error && (
+            {marketsError && (
               <div className="mt-4 p-3 bg-red-500/10 border border-red-500/30 rounded text-red-600 text-sm">
-                <strong>Error:</strong> {error.message}
+                <strong>Error:</strong> {marketsError.message}
               </div>
             )}
           </CardContent>
         </Card>
 
-        {/* Prices Table */}
-        <Card>
-          <CardHeader className="pb-4">
-            <CardTitle className="text-base font-medium">Oracle Prices</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Asset</TableHead>
-                    <TableHead>Symbol</TableHead>
-                    <TableHead className="text-right">Price (USD)</TableHead>
-                    <TableHead className="text-right">Confidence</TableHead>
-                    <TableHead className="text-right">Conf %</TableHead>
-                    <TableHead>Publish Time</TableHead>
-                    <TableHead>Age</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Feed ID</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {ALL_DENOMS.map((denom) => {
-                    const feed = DEFAULT_PYTH_FEEDS[denom];
-                    const price = prices[denom];
-                    const rawPrice = rawPrices[denom];
-
-                    const ageSeconds = rawPrice ? now - rawPrice.publishTime : null;
-                    const isStalePrice = ageSeconds !== null && ageSeconds > PYTH_STALENESS_THRESHOLD_SECONDS;
-                    const confidencePercent = rawPrice && rawPrice.price
-                      ? (rawPrice.confidence / rawPrice.price) * 100
-                      : null;
-
-                    return (
-                      <TableRow key={denom} className={isStalePrice ? 'bg-yellow-500/5' : ''}>
-                        <TableCell className="font-mono font-medium">{denom}</TableCell>
-                        <TableCell className="text-muted-foreground">{feed.symbol}</TableCell>
-                        <TableCell className="text-right font-mono">
-                          {price !== undefined ? (
-                            <span className={isStalePrice ? 'text-yellow-600' : ''}>
-                              ${price.toFixed(price < 1 ? 6 : 4)}
-                            </span>
-                          ) : (
-                            <span className="text-muted-foreground">—</span>
-                          )}
-                        </TableCell>
-                        <TableCell className="text-right font-mono">
-                          {rawPrice ? (
-                            <span className="text-muted-foreground">
-                              ±${rawPrice.confidence.toFixed(rawPrice.confidence < 0.01 ? 6 : 4)}
-                            </span>
-                          ) : (
-                            <span className="text-muted-foreground">—</span>
-                          )}
-                        </TableCell>
-                        <TableCell className="text-right font-mono">
-                          {confidencePercent !== null ? (
-                            <span className={confidencePercent > 1 ? 'text-yellow-600' : 'text-muted-foreground'}>
-                              {confidencePercent.toFixed(3)}%
-                            </span>
-                          ) : (
-                            <span className="text-muted-foreground">—</span>
-                          )}
-                        </TableCell>
-                        <TableCell className="font-mono text-xs text-muted-foreground">
-                          {rawPrice ? formatTimestamp(rawPrice.publishTime) : '—'}
-                        </TableCell>
-                        <TableCell className="font-mono">
-                          {ageSeconds !== null ? (
-                            <span className={isStalePrice ? 'text-yellow-600 font-medium' : ''}>
-                              {formatAge(rawPrice!.publishTime)}
-                            </span>
-                          ) : (
-                            <span className="text-muted-foreground">—</span>
-                          )}
-                        </TableCell>
-                        <TableCell>
-                          {rawPrice ? (
-                            isStalePrice ? (
-                              <span className="inline-flex items-center gap-1 text-yellow-600">
-                                <AlertTriangle className="h-3 w-3" />
-                                Stale
-                              </span>
-                            ) : (
-                              <span className="inline-flex items-center gap-1 text-green-600">
-                                <CheckCircle className="h-3 w-3" />
-                                Fresh
-                              </span>
-                            )
-                          ) : (
-                            <span className="text-muted-foreground">No data</span>
-                          )}
-                        </TableCell>
-                        <TableCell>
-                          <div className="flex items-center gap-1">
-                            <code className="text-xs text-muted-foreground">
-                              {shortenFeedId(feed.feedId)}
-                            </code>
-                            <button
-                              onClick={() => copyToClipboard(feed.feedId)}
-                              className="text-muted-foreground hover:text-foreground p-1"
-                              title="Copy feed ID"
-                            >
-                              <Copy className="h-3 w-3" />
-                            </button>
-                            <a
-                              href={`https://www.pyth.network/price-feeds/${feed.symbol.toLowerCase().replace('/', '-')}`}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="text-muted-foreground hover:text-foreground p-1"
-                              title="View on Pyth"
-                            >
-                              <ExternalLink className="h-3 w-3" />
-                            </a>
-                          </div>
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
+        {/* Legend Card */}
+        <Card className="mb-6">
+          <CardContent className="pt-4">
+            <div className="flex flex-wrap gap-6 text-sm">
+              <div className="flex items-center gap-2">
+                <span>🟢</span>
+                <span className="text-muted-foreground">Fresh (&lt;60s)</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span>🟡</span>
+                <span className="text-muted-foreground">Warning (60-180s)</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span>🔴</span>
+                <span className="text-muted-foreground">Stale (&gt;300s)</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span>❌</span>
+                <span className="text-muted-foreground">Error</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span>⏳</span>
+                <span className="text-muted-foreground">Loading</span>
+              </div>
             </div>
           </CardContent>
         </Card>
 
-        {/* Raw Data Card (collapsible) */}
+        {/* Oracle Cards */}
+        {isLoading && oracles.size === 0 ? (
+          <Card>
+            <CardContent className="py-12 text-center text-muted-foreground">
+              <RefreshCw className="h-8 w-8 animate-spin mx-auto mb-4" />
+              <p>Loading oracle data...</p>
+            </CardContent>
+          </Card>
+        ) : oracles.size === 0 ? (
+          <Card>
+            <CardContent className="py-12 text-center text-muted-foreground">
+              <Database className="h-8 w-8 mx-auto mb-4 opacity-50" />
+              <p>No oracles found. Are there any markets deployed?</p>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-6">
+            {Array.from(oracles.entries()).map(([address, state]) => (
+              <OracleCard
+                key={address}
+                oracleAddress={address}
+                state={state}
+                markets={marketsByOracle.get(address)?.map(m => ({
+                  id: m.id,
+                  address: m.marketAddress,
+                  collateralDenom: m.collateralDenom,
+                  debtDenom: m.debtDenom,
+                })) ?? []}
+                now={now}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Raw Data Section */}
         <details className="mt-6">
           <summary className="cursor-pointer text-sm text-muted-foreground hover:text-foreground mb-2">
-            Show raw price data (JSON)
+            Show raw oracle data (JSON)
           </summary>
           <Card>
             <CardContent className="pt-4">
               <pre className="text-xs overflow-auto max-h-96 p-4 bg-muted rounded">
                 {JSON.stringify(
                   {
-                    config: {
-                      hermesUrl: PYTH_HERMES_URL,
-                      mode: PYTH_MODE,
-                      contractAddress: PYTH_CONTRACT_ADDRESS,
-                      stalenessThreshold: PYTH_STALENESS_THRESHOLD_SECONDS,
-                    },
-                    feeds: DEFAULT_PYTH_FEEDS,
-                    currentPrices: rawPrices,
+                    rpcEndpoint: RPC_ENDPOINT,
+                    chainId: CHAIN_ID,
+                    markets: marketsData?.markets?.map(m => ({
+                      id: m.id,
+                      address: m.marketAddress,
+                      collateralDenom: m.collateralDenom,
+                      debtDenom: m.debtDenom,
+                      oracle: m.oracle,
+                    })),
+                    oracles: Array.from(oracles.entries()).map(([addr, state]) => ({
+                      address: addr,
+                      config: state.config,
+                      configError: state.configError,
+                      priceFeeds: state.priceFeeds,
+                      priceFeedsError: state.priceFeedsError,
+                      prices: Object.fromEntries(state.prices),
+                      priceErrors: Object.fromEntries(state.priceErrors),
+                    })),
                   },
                   null,
                   2
@@ -323,7 +590,7 @@ export default function OracleDebugPage() {
         {/* Footer */}
         <div className="mt-8 text-center text-sm text-muted-foreground">
           <p>
-            This is a debug page for development purposes.
+            This dashboard queries the oracle contracts directly via CosmJS.
             Prices refresh every 10 seconds automatically.
           </p>
         </div>

--- a/frontend/hooks/useOracleQuery.ts
+++ b/frontend/hooks/useOracleQuery.ts
@@ -1,0 +1,331 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { CosmWasmClient } from '@cosmjs/cosmwasm-stargate';
+import { RPC_ENDPOINT } from '@/lib/constants';
+
+// Oracle contract query messages
+interface OracleConfigQuery {
+  config: Record<string, never>;
+}
+
+interface OracleAllPriceFeedsQuery {
+  all_price_feeds: Record<string, never>;
+}
+
+interface OraclePriceQuery {
+  price: {
+    denom: string;
+  };
+}
+
+// Oracle contract response types
+export interface OracleConfig {
+  owner: string;
+  pyth_contract_addr: string;
+  max_confidence_ratio: string;
+}
+
+export interface OraclePriceFeed {
+  denom: string;
+  feed_id: string;
+}
+
+export interface OraclePrice {
+  denom: string;
+  price: string;
+  updated_at: number;
+}
+
+// Error types for oracle queries
+export interface OraclePriceError {
+  denom: string;
+  error: string;
+}
+
+// Combined oracle state for a single oracle contract
+export interface OracleState {
+  address: string;
+  config: OracleConfig | null;
+  configError: string | null;
+  priceFeeds: OraclePriceFeed[];
+  priceFeedsError: string | null;
+  prices: Map<string, OraclePrice>;
+  priceErrors: Map<string, string>;
+  isLoading: boolean;
+  lastUpdated: Date | null;
+}
+
+// Staleness thresholds in seconds
+export const STALENESS_FRESH_THRESHOLD = 60; // 60s - definitely fresh
+export const STALENESS_WARNING_THRESHOLD = 180; // 3 min - warning
+export const STALENESS_STALE_THRESHOLD = 300; // 5 min - stale
+
+export type PriceStatus = 'fresh' | 'warning' | 'stale' | 'error' | 'loading';
+
+export function getPriceStatus(updatedAt: number | null, hasError: boolean): PriceStatus {
+  if (hasError) return 'error';
+  if (updatedAt === null) return 'loading';
+  
+  const now = Math.floor(Date.now() / 1000);
+  const age = now - updatedAt;
+  
+  if (age <= STALENESS_FRESH_THRESHOLD) return 'fresh';
+  if (age <= STALENESS_WARNING_THRESHOLD) return 'warning';
+  return 'stale';
+}
+
+export function getStatusEmoji(status: PriceStatus): string {
+  switch (status) {
+    case 'fresh': return '🟢';
+    case 'warning': return '🟡';
+    case 'stale': return '🔴';
+    case 'error': return '❌';
+    case 'loading': return '⏳';
+  }
+}
+
+// Parse contract error messages
+function parseContractError(error: unknown): string {
+  if (error instanceof Error) {
+    const msg = error.message;
+    
+    // Extract the contract error from the full message
+    // Common patterns: "ConfidenceTooHigh", "PriceFeedNotConfigured", etc.
+    const contractErrorMatch = msg.match(/error executing.*?:(.*?)(?:$|query wasm)/i);
+    if (contractErrorMatch) {
+      return contractErrorMatch[1].trim();
+    }
+    
+    // Look for specific error types
+    if (msg.includes('ConfidenceTooHigh')) return 'ConfidenceTooHigh';
+    if (msg.includes('PriceFeedNotConfigured')) return 'PriceFeedNotConfigured';
+    if (msg.includes('PriceStale')) return 'PriceStale';
+    if (msg.includes('not found')) return 'PriceFeedNotConfigured';
+    
+    // Return the full message if we can't extract a specific error
+    return msg.length > 100 ? msg.substring(0, 100) + '...' : msg;
+  }
+  return 'Unknown error';
+}
+
+// Async function to query a single oracle (not a hook)
+async function queryOracleContract(
+  client: CosmWasmClient,
+  oracleAddress: string,
+  denoms: string[]
+): Promise<OracleState> {
+  const oracleState: OracleState = {
+    address: oracleAddress,
+    config: null,
+    configError: null,
+    priceFeeds: [],
+    priceFeedsError: null,
+    prices: new Map(),
+    priceErrors: new Map(),
+    isLoading: false,
+    lastUpdated: new Date(),
+  };
+
+  // Query config
+  try {
+    const configQuery: OracleConfigQuery = { config: {} };
+    oracleState.config = await client.queryContractSmart(oracleAddress, configQuery);
+  } catch (e) {
+    oracleState.configError = parseContractError(e);
+  }
+
+  // Query all price feeds
+  try {
+    const feedsQuery: OracleAllPriceFeedsQuery = { all_price_feeds: {} };
+    oracleState.priceFeeds = await client.queryContractSmart(oracleAddress, feedsQuery);
+  } catch (e) {
+    oracleState.priceFeedsError = parseContractError(e);
+  }
+
+  // Query prices for each denom
+  const uniqueDenoms = [...new Set(denoms)];
+  await Promise.all(
+    uniqueDenoms.map(async (denom) => {
+      try {
+        const priceQuery: OraclePriceQuery = { price: { denom } };
+        const price: OraclePrice = await client.queryContractSmart(oracleAddress, priceQuery);
+        oracleState.prices.set(denom, price);
+      } catch (e) {
+        oracleState.priceErrors.set(denom, parseContractError(e));
+      }
+    })
+  );
+
+  return oracleState;
+}
+
+// Single oracle query hook
+export function useOracleQuery(
+  oracleAddress: string | undefined,
+  denoms: string[],
+  refreshInterval: number = 10000
+): OracleState {
+  const [state, setState] = useState<OracleState>({
+    address: oracleAddress || '',
+    config: null,
+    configError: null,
+    priceFeeds: [],
+    priceFeedsError: null,
+    prices: new Map(),
+    priceErrors: new Map(),
+    isLoading: true,
+    lastUpdated: null,
+  });
+
+  // Use ref to track if we're mounted to avoid state updates on unmounted component
+  const isMountedRef = useRef(true);
+
+  const queryOracle = useCallback(async () => {
+    if (!oracleAddress) {
+      setState(prev => ({
+        ...prev,
+        isLoading: false,
+        configError: 'No oracle address provided',
+      }));
+      return;
+    }
+
+    try {
+      const client = await CosmWasmClient.connect(RPC_ENDPOINT);
+      const result = await queryOracleContract(client, oracleAddress, denoms);
+      
+      if (isMountedRef.current) {
+        setState(result);
+      }
+    } catch (e) {
+      if (isMountedRef.current) {
+        setState(prev => ({
+          ...prev,
+          isLoading: false,
+          configError: parseContractError(e),
+        }));
+      }
+    }
+  }, [oracleAddress, denoms]);
+
+  // Initial query and refresh interval
+  useEffect(() => {
+    isMountedRef.current = true;
+    
+    // Initial query
+    queryOracle();
+
+    // Set up refresh interval
+    let interval: NodeJS.Timeout | undefined;
+    if (refreshInterval > 0) {
+      interval = setInterval(queryOracle, refreshInterval);
+    }
+
+    return () => {
+      isMountedRef.current = false;
+      if (interval) {
+        clearInterval(interval);
+      }
+    };
+  }, [queryOracle, refreshInterval]);
+
+  return state;
+}
+
+// Hook for querying multiple oracles
+export interface MultiOracleState {
+  oracles: Map<string, OracleState>;
+  isLoading: boolean;
+  lastUpdated: Date | null;
+}
+
+export function useMultipleOracleQueries(
+  oracleConfigs: Array<{ address: string; denoms: string[] }>,
+  refreshInterval: number = 10000
+): MultiOracleState {
+  const [state, setState] = useState<MultiOracleState>({
+    oracles: new Map(),
+    isLoading: true,
+    lastUpdated: null,
+  });
+
+  // Use ref to track if we're mounted
+  const isMountedRef = useRef(true);
+  
+  // Serialize oracleConfigs to use as dependency
+  const configsKey = JSON.stringify(
+    oracleConfigs.map(c => ({ address: c.address, denoms: c.denoms.sort() }))
+  );
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    
+    const queryAllOracles = async () => {
+      if (oracleConfigs.length === 0) {
+        if (isMountedRef.current) {
+          setState({
+            oracles: new Map(),
+            isLoading: false,
+            lastUpdated: new Date(),
+          });
+        }
+        return;
+      }
+
+      try {
+        const client = await CosmWasmClient.connect(RPC_ENDPOINT);
+        const oracles = new Map<string, OracleState>();
+
+        // Deduplicate by oracle address
+        const uniqueOracles = new Map<string, string[]>();
+        for (const config of oracleConfigs) {
+          const existing = uniqueOracles.get(config.address) || [];
+          uniqueOracles.set(config.address, [...new Set([...existing, ...config.denoms])]);
+        }
+
+        await Promise.all(
+          Array.from(uniqueOracles.entries()).map(async ([address, denoms]) => {
+            const oracleState = await queryOracleContract(client, address, denoms);
+            oracles.set(address, oracleState);
+          })
+        );
+
+        if (isMountedRef.current) {
+          setState({
+            oracles,
+            isLoading: false,
+            lastUpdated: new Date(),
+          });
+        }
+      } catch (e) {
+        console.error('Failed to query oracles:', e);
+        if (isMountedRef.current) {
+          setState(prev => ({
+            ...prev,
+            isLoading: false,
+          }));
+        }
+      }
+    };
+
+    // Initial query
+    queryAllOracles();
+
+    // Set up refresh interval
+    let interval: NodeJS.Timeout | undefined;
+    if (refreshInterval > 0) {
+      interval = setInterval(queryAllOracles, refreshInterval);
+    }
+
+    return () => {
+      isMountedRef.current = false;
+      if (interval) {
+        clearInterval(interval);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [configsKey, refreshInterval]);
+
+  return state;
+}

--- a/frontend/lib/graphql/generated/hooks.ts
+++ b/frontend/lib/graphql/generated/hooks.ts
@@ -279,7 +279,7 @@ export type UserPositionTransactionsArgs = {
 
 export type MarketFieldsFragment = { __typename?: 'Market', id: string, marketAddress: string, curator: string, collateralDenom: string, debtDenom: string, oracle: string, createdAt: string, createdAtBlock: number, loanToValue: string, liquidationThreshold: string, liquidationBonus: string, liquidationProtocolFee: string, closeFactor: string, interestRateModel: Record<string, unknown>, protocolFee: string, curatorFee: string, supplyCap?: string | null, borrowCap?: string | null, enabled: boolean, isMutable: boolean, borrowIndex: string, liquidityIndex: string, borrowRate: string, liquidityRate: string, totalSupply: string, totalDebt: string, totalCollateral: string, utilization: string, availableLiquidity: string, lastUpdate: number };
 
-export type MarketSummaryFieldsFragment = { __typename?: 'Market', id: string, marketAddress: string, collateralDenom: string, debtDenom: string, curator: string, loanToValue: string, liquidationThreshold: string, borrowRate: string, liquidityRate: string, totalSupply: string, totalDebt: string, totalCollateral: string, utilization: string, availableLiquidity: string, enabled: boolean };
+export type MarketSummaryFieldsFragment = { __typename?: 'Market', id: string, marketAddress: string, collateralDenom: string, debtDenom: string, curator: string, oracle: string, loanToValue: string, liquidationThreshold: string, borrowRate: string, liquidityRate: string, totalSupply: string, totalDebt: string, totalCollateral: string, utilization: string, availableLiquidity: string, enabled: boolean };
 
 export type PositionFieldsFragment = { __typename?: 'UserPosition', id: string, userAddress: string, supplyScaled: string, debtScaled: string, collateral: string, supplyAmount: string, debtAmount: string, healthFactor?: string | null, firstInteraction: string, lastInteraction: string, market: { __typename?: 'Market', id: string, marketAddress: string, collateralDenom: string, debtDenom: string, loanToValue: string, liquidationThreshold: string, liquidityIndex: string, borrowIndex: string } };
 
@@ -295,7 +295,7 @@ export type GetMarketsQueryVariables = Exact<{
 }>;
 
 
-export type GetMarketsQuery = { __typename?: 'Query', markets: Array<{ __typename?: 'Market', id: string, marketAddress: string, collateralDenom: string, debtDenom: string, curator: string, loanToValue: string, liquidationThreshold: string, borrowRate: string, liquidityRate: string, totalSupply: string, totalDebt: string, totalCollateral: string, utilization: string, availableLiquidity: string, enabled: boolean }> };
+export type GetMarketsQuery = { __typename?: 'Query', markets: Array<{ __typename?: 'Market', id: string, marketAddress: string, collateralDenom: string, debtDenom: string, curator: string, oracle: string, loanToValue: string, liquidationThreshold: string, borrowRate: string, liquidityRate: string, totalSupply: string, totalDebt: string, totalCollateral: string, utilization: string, availableLiquidity: string, enabled: boolean }> };
 
 export type GetMarketQueryVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -440,6 +440,7 @@ export const MarketSummaryFieldsFragmentDoc = gql`
   collateralDenom
   debtDenom
   curator
+  oracle
   loanToValue
   liquidationThreshold
   borrowRate

--- a/frontend/lib/graphql/queries.ts
+++ b/frontend/lib/graphql/queries.ts
@@ -46,6 +46,7 @@ export const MARKET_SUMMARY_FIELDS = gql`
     collateralDenom
     debtDenom
     curator
+    oracle
     loanToValue
     liquidationThreshold
     borrowRate


### PR DESCRIPTION
## What

Rebuilt the oracle debug dashboard at `/debug/oracle` to query our oracle contracts directly instead of the Pyth Hermes API.

## Why

The previous implementation was incorrect — it queried Pyth's Hermes API directly, which doesn't reflect what the market contracts actually see. The market contracts query our oracle adapter contracts, which have their own configuration, caching, and error handling.

## How

1. **New `useOracleQuery` hook** — Queries oracle contracts via CosmWasm:
   - `{ config: {} }` — Get oracle configuration (pyth contract, max confidence ratio)
   - `{ all_price_feeds: {} }` — Get configured denom → feed ID mappings
   - `{ price: { denom } }` — Get live price for each relevant denom

2. **Market-aware display** — Gets markets from GraphQL, groups by oracle address, and queries prices for each market's collateral and debt denoms.

3. **Status indicators**:
   - 🟢 Fresh (<60s)
   - 🟡 Warning (60-180s)
   - 🔴 Stale (>300s)
   - ❌ Error (with error message)

4. **Error display** — Shows contract errors like `ConfidenceTooHigh`, `PriceFeedNotConfigured`, etc.

## Changes

- `frontend/hooks/useOracleQuery.ts` — New hook for oracle contract queries
- `frontend/app/debug/oracle/page.tsx` — Rebuilt dashboard
- `frontend/lib/graphql/queries.ts` — Added `oracle` field to `MarketSummaryFields`
- `frontend/lib/graphql/generated/hooks.ts` — Updated types to include oracle field

## Testing

- [x] Build passes (`npm run build`)
- [x] Lint passes for new files
- [x] Manual testing with local chain recommended

## Checklist

- [x] Code follows project conventions
- [x] Commit messages follow conventional format
- [x] No unrelated changes included

---

🤖 Implemented by Claude (Anthropic)