### PR TITLE
fix(ci): build mock-pyth and pyth-oracle-adapter WASM contracts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,12 +36,16 @@ jobs:
           cargo build --release --target wasm32-unknown-unknown -p stone-factory
           cargo build --release --target wasm32-unknown-unknown -p stone-market
           cargo build --release --target wasm32-unknown-unknown -p mock-oracle
+          cargo build --release --target wasm32-unknown-unknown -p mock-pyth
+          cargo build --release --target wasm32-unknown-unknown -p pyth-oracle-adapter
 
           # Create artifacts directory
           mkdir -p artifacts
           cp target/wasm32-unknown-unknown/release/stone_factory.wasm artifacts/
           cp target/wasm32-unknown-unknown/release/stone_market.wasm artifacts/
           cp target/wasm32-unknown-unknown/release/mock_oracle.wasm artifacts/
+          cp target/wasm32-unknown-unknown/release/mock_pyth.wasm artifacts/
+          cp target/wasm32-unknown-unknown/release/pyth_oracle_adapter.wasm artifacts/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What
Add missing WASM contracts to the E2E workflow build step.

## Why
E2E tests are failing because `mock_pyth.wasm` is not being built in CI. The deployer expects it at `/artifacts/mock_pyth.wasm`.

Error:
```
stone-deployer | Deployment failed: Error: ENOENT: no such file or directory, open '/artifacts/mock_pyth.wasm'
```

## How
Updated `.github/workflows/e2e.yml` to also build and copy:
- `mock-pyth` → `mock_pyth.wasm`
- `pyth-oracle-adapter` → `pyth_oracle_adapter.wasm`

## Testing
- [x] Verified package names in `contracts/mock-pyth/Cargo.toml` and `contracts/pyth-oracle-adapter/Cargo.toml`
- [ ] CI should pass after merge

## Checklist
- [x] Code follows project conventions
- [x] Commit messages follow conventional format
- [x] No unrelated changes included

---
🤖 Implemented by Claude (Anthropic)